### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "2f4421a361d429e56df0fcc7f7d8c97c16f8c0d4",
+  "baseline-sha": "b424d9c9cba0dd11b900c252464a20bba7bde395",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.1.0",
-      "tag": "v0.1.0"
+      "version": "0.2.0",
+      "tag": "v0.2.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.0](https://github.com/jolars/basin/compare/v0.1.0...v0.2.0) (2026-05-19)
+
+### Breaking changes
+- bump MSRV to 1.91.1 and unwind CRAN-related dep pins ([`2a64a51`](https://github.com/jolars/basin/commit/2a64a518d55db9b106fa2b2d08729462725da175))
+
+### Features
+- add `ndarray-blas` feature ([`b424d9c`](https://github.com/jolars/basin/commit/b424d9c9cba0dd11b900c252464a20bba7bde395))
+- add `parallel` feature ([`7919632`](https://github.com/jolars/basin/commit/79196320d669d80a16581a03fdbea1917e6821a5))
+- implement L-BFGS (unbounded) ([`4df3dbb`](https://github.com/jolars/basin/commit/4df3dbb1296ffdc55d786addc08842226d3cd905))
+
+### Performance Improvements
+- **nlls:** cache r and J across iterations in GN, LM, TRF ([`aef1197`](https://github.com/jolars/basin/commit/aef11970d2fe24beabd5b63f93fd3f4633829049))
 ## [0.1.0](https://github.com/jolars/basin/compare/v0.0.1...v0.1.0) (2026-05-19)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "basin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "faer",
  "generativity",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.2.0](https://github.com/jolars/basin/compare/v0.1.0...v0.2.0) (2026-05-19)

### Breaking changes
- bump MSRV to 1.91.1 and unwind CRAN-related dep pins ([`2a64a51`](https://github.com/jolars/basin/commit/2a64a518d55db9b106fa2b2d08729462725da175))

### Features
- add `ndarray-blas` feature ([`b424d9c`](https://github.com/jolars/basin/commit/b424d9c9cba0dd11b900c252464a20bba7bde395))
- add `parallel` feature ([`7919632`](https://github.com/jolars/basin/commit/79196320d669d80a16581a03fdbea1917e6821a5))
- implement L-BFGS (unbounded) ([`4df3dbb`](https://github.com/jolars/basin/commit/4df3dbb1296ffdc55d786addc08842226d3cd905))

### Performance Improvements
- **nlls:** cache r and J across iterations in GN, LM, TRF ([`aef1197`](https://github.com/jolars/basin/commit/aef11970d2fe24beabd5b63f93fd3f4633829049))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).