### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "b424d9c9cba0dd11b900c252464a20bba7bde395",
+  "baseline-sha": "d4f17436eb418e13c8f825a6be42ebcb397273c6",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.2.0",
-      "tag": "v0.2.0"
+      "version": "0.3.0",
+      "tag": "v0.3.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.3.0](https://github.com/jolars/basin/compare/v0.2.0...v0.3.0) (2026-05-20)
+
+### Breaking changes
+- **nlls:** damp Levenberg-Marquardt with Marquardt diagonal scaling ([`fdde644`](https://github.com/jolars/basin/commit/fdde64488cc788052f2016959657a86e5e142ba4)), closes [#6](https://github.com/jolars/basin/issues/6)
+
+### Features
+- add competitor-bench crate for comparisons ([`bbacbf6`](https://github.com/jolars/basin/commit/bbacbf6d12aa486a3eac521b34a6f47f5cd5a66b))
+- **nlls:** add MINPACK ftol/xtol convergence tests to Levenberg-Marquardt ([`2bad473`](https://github.com/jolars/basin/commit/2bad473685f87d0a6b472e546689a1ea567819ca)), closes [#8](https://github.com/jolars/basin/issues/8)
+- **termination:** add RelativeGradientTolerance framework criterion ([`70b5cb6`](https://github.com/jolars/basin/commit/70b5cb6f6c9e12f6c07ace6c256e583167cbd7ab))
+- **nlls:** add MINPACK gtol (relative gradient) test to Levenberg-Marquardt ([`5a60145`](https://github.com/jolars/basin/commit/5a601451ea4c41b4a1eee2424cb5d58766962fbc))
+
+### Bug Fixes
+- **nlls:** damp Levenberg-Marquardt with Marquardt diagonal scaling ([`fdde644`](https://github.com/jolars/basin/commit/fdde64488cc788052f2016959657a86e5e142ba4)), closes [#6](https://github.com/jolars/basin/issues/6)
+
+### Performance Improvements
+- **nlls:** reuse JᵀJ and Jᵀr across rejected Levenberg-Marquardt steps ([`deb9bae`](https://github.com/jolars/basin/commit/deb9bae565397b928062db836e517f852446639c))
 ## [0.2.0](https://github.com/jolars/basin/compare/v0.1.0...v0.2.0) (2026-05-19)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "basin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "faer",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -235,7 +235,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "competitor-bench"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -376,9 +376,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "enum-as-inner"

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -18,7 +18,7 @@
 # support natively, so GD / Nelder-Mead run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.0.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.3.0](https://github.com/jolars/basin/compare/v0.2.0...v0.3.0) (2026-05-20)

### Breaking changes
- **nlls:** damp Levenberg-Marquardt with Marquardt diagonal scaling ([`fdde644`](https://github.com/jolars/basin/commit/fdde64488cc788052f2016959657a86e5e142ba4)), closes [#6](https://github.com/jolars/basin/issues/6)

### Features
- add competitor-bench crate for comparisons ([`bbacbf6`](https://github.com/jolars/basin/commit/bbacbf6d12aa486a3eac521b34a6f47f5cd5a66b))
- **nlls:** add MINPACK ftol/xtol convergence tests to Levenberg-Marquardt ([`2bad473`](https://github.com/jolars/basin/commit/2bad473685f87d0a6b472e546689a1ea567819ca)), closes [#8](https://github.com/jolars/basin/issues/8)
- **termination:** add RelativeGradientTolerance framework criterion ([`70b5cb6`](https://github.com/jolars/basin/commit/70b5cb6f6c9e12f6c07ace6c256e583167cbd7ab))
- **nlls:** add MINPACK gtol (relative gradient) test to Levenberg-Marquardt ([`5a60145`](https://github.com/jolars/basin/commit/5a601451ea4c41b4a1eee2424cb5d58766962fbc))

### Bug Fixes
- **nlls:** damp Levenberg-Marquardt with Marquardt diagonal scaling ([`fdde644`](https://github.com/jolars/basin/commit/fdde64488cc788052f2016959657a86e5e142ba4)), closes [#6](https://github.com/jolars/basin/issues/6)

### Performance Improvements
- **nlls:** reuse JᵀJ and Jᵀr across rejected Levenberg-Marquardt steps ([`deb9bae`](https://github.com/jolars/basin/commit/deb9bae565397b928062db836e517f852446639c))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).