### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "d4f17436eb418e13c8f825a6be42ebcb397273c6",
+  "baseline-sha": "fb97d0afd8d6c389cd747ab7ea0942cc4838dc77",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.3.0",
-      "tag": "v0.3.0"
+      "version": "0.4.0",
+      "tag": "v0.4.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.0](https://github.com/jolars/basin/compare/v0.3.0...v0.4.0) (2026-05-21)
+
+### Features
+- add per-coordinate initial step-size to CMA-ES (with_stds) ([`fb97d0a`](https://github.com/jolars/basin/commit/fb97d0afd8d6c389cd747ab7ea0942cc4838dc77))
+- add numerical gradients/hessians/jacobians ([`bef3fdc`](https://github.com/jolars/basin/commit/bef3fdcd2dd5b5350faafbe510fa75de8a895993))
+- add Polyak momentum to GD solver ([`9b9ab93`](https://github.com/jolars/basin/commit/9b9ab9351e6814e9310cd4970918855d7ce5a8f9))
+- **web:** restructure into landing + docs + visualizer site ([`727de34`](https://github.com/jolars/basin/commit/727de34e4afc51431003b171b850ae74dfc0efcb))
 ## [0.3.0](https://github.com/jolars/basin/compare/v0.2.0...v0.3.0) (2026-05-20)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "basin"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "faer",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -244,7 +244,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "competitor-bench"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "argmin",
  "argmin-math",

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -18,7 +18,7 @@
 # support natively, so GD / Nelder-Mead run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.4.0](https://github.com/jolars/basin/compare/v0.3.0...v0.4.0) (2026-05-21)

### Features
- add per-coordinate initial step-size to CMA-ES (with_stds) ([`fb97d0a`](https://github.com/jolars/basin/commit/fb97d0afd8d6c389cd747ab7ea0942cc4838dc77))
- add numerical gradients/hessians/jacobians ([`bef3fdc`](https://github.com/jolars/basin/commit/bef3fdcd2dd5b5350faafbe510fa75de8a895993))
- add Polyak momentum to GD solver ([`9b9ab93`](https://github.com/jolars/basin/commit/9b9ab9351e6814e9310cd4970918855d7ce5a8f9))
- **web:** restructure into landing + docs + visualizer site ([`727de34`](https://github.com/jolars/basin/commit/727de34e4afc51431003b171b850ae74dfc0efcb))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).