### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "fb97d0afd8d6c389cd747ab7ea0942cc4838dc77",
+  "baseline-sha": "802b2910e82a298ae7d16ce71d341693ccc16cc2",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.4.0",
-      "tag": "v0.4.0"
+      "version": "0.5.0",
+      "tag": "v0.5.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.5.0](https://github.com/jolars/basin/compare/v0.4.0...v0.5.0) (2026-05-26)
+
+### Breaking changes
+- make barrier/augmented-Lagrangian methods inner-solver-agnostic ([`5a4f369`](https://github.com/jolars/basin/commit/5a4f369773ff3828fe14853deaf2982b9630ad2f))
+- rename BoxConstrained → BoxConstraints ([`7d60b0f`](https://github.com/jolars/basin/commit/7d60b0ffdf42cc655a2df8b60ddd1f08467cdc2e))
+
+### Features
+- add `MatVec` + `MatTransposeVec` to vec, ndarray backends ([`320173f`](https://github.com/jolars/basin/commit/320173f5bf0ae0389163a3586dcdfde01f6e0509))
+- make barrier/augmented-Lagrangian methods inner-solver-agnostic ([`5a4f369`](https://github.com/jolars/basin/commit/5a4f369773ff3828fe14853deaf2982b9630ad2f))
+- add linear equality constraints (Ax = b) and augmented Lagrangian method ([`aa038bc`](https://github.com/jolars/basin/commit/aa038bcff613d173dae584e437fa38151ee2cbf9))
+- add linear inequality constraints (Ax ≤ b) and log-barrier method ([`c7f2e24`](https://github.com/jolars/basin/commit/c7f2e24f493a7d8ae3c92016e747761ce8c67f67))
+- **web:** live contour beside the playground code (phase 2) ([`8a21eda`](https://github.com/jolars/basin/commit/8a21edabadc86ed89c114e79f54cbe855dbd263c))
+- **web:** add interactive code-gen playground to landing page ([`29f10b2`](https://github.com/jolars/basin/commit/29f10b2e65bae65e3ce60983fb05c5206d99419b))
 ## [0.4.0](https://github.com/jolars/basin/compare/v0.3.0...v0.4.0) (2026-05-21)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,13 +90,13 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "faer",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -129,9 +129,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -244,7 +244,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "competitor-bench"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -838,9 +838,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -880,9 +880,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loom"
@@ -1503,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1769,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -18,7 +18,7 @@
 # support natively, so GD / Nelder-Mead run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.5.0](https://github.com/jolars/basin/compare/v0.4.0...v0.5.0) (2026-05-26)

### Breaking changes
- make barrier/augmented-Lagrangian methods inner-solver-agnostic ([`5a4f369`](https://github.com/jolars/basin/commit/5a4f369773ff3828fe14853deaf2982b9630ad2f))
- rename BoxConstrained → BoxConstraints ([`7d60b0f`](https://github.com/jolars/basin/commit/7d60b0ffdf42cc655a2df8b60ddd1f08467cdc2e))

### Features
- add `MatVec` + `MatTransposeVec` to vec, ndarray backends ([`320173f`](https://github.com/jolars/basin/commit/320173f5bf0ae0389163a3586dcdfde01f6e0509))
- make barrier/augmented-Lagrangian methods inner-solver-agnostic ([`5a4f369`](https://github.com/jolars/basin/commit/5a4f369773ff3828fe14853deaf2982b9630ad2f))
- add linear equality constraints (Ax = b) and augmented Lagrangian method ([`aa038bc`](https://github.com/jolars/basin/commit/aa038bcff613d173dae584e437fa38151ee2cbf9))
- add linear inequality constraints (Ax ≤ b) and log-barrier method ([`c7f2e24`](https://github.com/jolars/basin/commit/c7f2e24f493a7d8ae3c92016e747761ce8c67f67))
- **web:** live contour beside the playground code (phase 2) ([`8a21eda`](https://github.com/jolars/basin/commit/8a21edabadc86ed89c114e79f54cbe855dbd263c))
- **web:** add interactive code-gen playground to landing page ([`29f10b2`](https://github.com/jolars/basin/commit/29f10b2e65bae65e3ce60983fb05c5206d99419b))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).