### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "802b2910e82a298ae7d16ce71d341693ccc16cc2",
+  "baseline-sha": "0ca5d44d72fcd2a657c1498f0632991ec8676e07",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.5.0",
-      "tag": "v0.5.0"
+      "version": "0.6.0",
+      "tag": "v0.6.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.0](https://github.com/jolars/basin/compare/v0.5.0...v0.6.0) (2026-05-27)
+
+### Features
+- **backends:** support CmaEs in Vec backend ([`02ad27c`](https://github.com/jolars/basin/commit/02ad27c70e2adb629553be89d25da111e696d240))
+- **backends:** add ndarray support for LBFGS ([`58a298f`](https://github.com/jolars/basin/commit/58a298f5c7a7941e3f57207e1246c22b62a196ee))
+- **backends:** add Vec support for the BFGS solver ([`cf5f5ba`](https://github.com/jolars/basin/commit/cf5f5ba909f22082e6beab038154096da260610f))
 ## [0.5.0](https://github.com/jolars/basin/compare/v0.4.0...v0.5.0) (2026-05-26)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "faer",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -244,7 +244,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "competitor-bench"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nalgebra"
@@ -1939,18 +1939,18 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -18,7 +18,7 @@
 # support natively, so GD / Nelder-Mead run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.6.0](https://github.com/jolars/basin/compare/v0.5.0...v0.6.0) (2026-05-27)

### Features
- **backends:** support CmaEs in Vec backend ([`02ad27c`](https://github.com/jolars/basin/commit/02ad27c70e2adb629553be89d25da111e696d240))
- **backends:** add ndarray support for LBFGS ([`58a298f`](https://github.com/jolars/basin/commit/58a298f5c7a7941e3f57207e1246c22b62a196ee))
- **backends:** add Vec support for the BFGS solver ([`cf5f5ba`](https://github.com/jolars/basin/commit/cf5f5ba909f22082e6beab038154096da260610f))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).