### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "dea3304d55479ca55b669c351c5a3da1ce2660fe",
+  "baseline-sha": "7ee25a8ffb305eaddd03efae3e6d16b32eba1916",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.7.0",
-      "tag": "v0.7.0"
+      "version": "0.8.0",
+      "tag": "v0.8.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.8.0](https://github.com/jolars/basin/compare/v0.7.0...v0.8.0) (2026-05-29)
+
+### Breaking changes
+- **problem:** migrate to `Problem<P>` design, absorb counting ([`867f371`](https://github.com/jolars/basin/commit/867f371fa0ffe6a3df679d69323a8296f43c324a)), closes [#32](https://github.com/jolars/basin/issues/32)
+- **problem:** typed hard-abort error on problem traits ([`6b46d57`](https://github.com/jolars/basin/commit/6b46d570e651bc3ce74a0d989e9c16a1bb4f5f1c))
+
+### Features
+- dual-license the package under apache v2 and MIT ([`9a33eeb`](https://github.com/jolars/basin/commit/9a33eebd6a01f8e12b19ce8ddd43cc9b5746ad8a))
+- **solvers:** add differential evolution solver (`De`) ([`7a09e0a`](https://github.com/jolars/basin/commit/7a09e0a8bef8aaddb021e9615b7b953f9669e00e))
+- **problem:** migrate to `Problem<P>` design, absorb counting ([`867f371`](https://github.com/jolars/basin/commit/867f371fa0ffe6a3df679d69323a8296f43c324a)), closes [#32](https://github.com/jolars/basin/issues/32)
+- **problem:** typed hard-abort error on problem traits ([`6b46d57`](https://github.com/jolars/basin/commit/6b46d570e651bc3ce74a0d989e9c16a1bb4f5f1c))
+- **problem:** fused cost+grad/residual+jac via subtrait hierarchy ([`c08d595`](https://github.com/jolars/basin/commit/c08d5952f64697fdfd38634d817d71d5e857e8e8))
+- **termination:** add NoImprovement criterion ([`c06ff76`](https://github.com/jolars/basin/commit/c06ff7649d48e7a9dc09e809fddf45ab7f159cf6))
+- **termination:** add `TargetCost` criteria ([`690a82b`](https://github.com/jolars/basin/commit/690a82b1ffead98cdd3d15636adb909c3ebdefec))
 ## [0.7.0](https://github.com/jolars/basin/compare/v0.6.0...v0.7.0) (2026-05-28)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "faer",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "2c61cd05405eb1d0f3a4660f802bad76ece84b6e722426342ba5dd511f724e97"
 
 [[package]]
 name = "bumpalo"
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -244,7 +244,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "competitor-bench"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simba"

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -18,7 +18,7 @@
 # support natively, so GD / Nelder-Mead run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.8.0](https://github.com/jolars/basin/compare/v0.7.0...v0.8.0) (2026-05-29)

### Breaking changes
- **problem:** migrate to `Problem<P>` design, absorb counting ([`867f371`](https://github.com/jolars/basin/commit/867f371fa0ffe6a3df679d69323a8296f43c324a)), closes [#32](https://github.com/jolars/basin/issues/32)
- **problem:** typed hard-abort error on problem traits ([`6b46d57`](https://github.com/jolars/basin/commit/6b46d570e651bc3ce74a0d989e9c16a1bb4f5f1c))

### Features
- dual-license the package under apache v2 and MIT ([`9a33eeb`](https://github.com/jolars/basin/commit/9a33eebd6a01f8e12b19ce8ddd43cc9b5746ad8a))
- **solvers:** add differential evolution solver (`De`) ([`7a09e0a`](https://github.com/jolars/basin/commit/7a09e0a8bef8aaddb021e9615b7b953f9669e00e))
- **problem:** migrate to `Problem<P>` design, absorb counting ([`867f371`](https://github.com/jolars/basin/commit/867f371fa0ffe6a3df679d69323a8296f43c324a)), closes [#32](https://github.com/jolars/basin/issues/32)
- **problem:** typed hard-abort error on problem traits ([`6b46d57`](https://github.com/jolars/basin/commit/6b46d570e651bc3ce74a0d989e9c16a1bb4f5f1c))
- **problem:** fused cost+grad/residual+jac via subtrait hierarchy ([`c08d595`](https://github.com/jolars/basin/commit/c08d5952f64697fdfd38634d817d71d5e857e8e8))
- **termination:** add NoImprovement criterion ([`c06ff76`](https://github.com/jolars/basin/commit/c06ff7649d48e7a9dc09e809fddf45ab7f159cf6))
- **termination:** add `TargetCost` criteria ([`690a82b`](https://github.com/jolars/basin/commit/690a82b1ffead98cdd3d15636adb909c3ebdefec))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).