### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "7ca53421f6a398a7d523e74dd552d41892df65b6",
+  "baseline-sha": "ca34b5c88e79d3b6420a9e00af277704e6b0ef85",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.9.0",
-      "tag": "v0.9.0"
+      "version": "0.10.0",
+      "tag": "v0.10.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.10.0](https://github.com/jolars/basin/compare/v0.9.0...v0.10.0) (2026-06-02)
+
+### Breaking changes
+- add `best_cost`, `best_iter` and friends to `BasicState` ([`c5e425a`](https://github.com/jolars/basin/commit/c5e425a0e835dbf47ff7fc964f97ff966fa6fcec)), closes [#36](https://github.com/jolars/basin/issues/36)
+
+### Features
+- **solvers:** add `DeInject` solver ([`ca34b5c`](https://github.com/jolars/basin/commit/ca34b5c88e79d3b6420a9e00af277704e6b0ef85))
+- add `best_cost`, `best_iter` and friends to `BasicState` ([`c5e425a`](https://github.com/jolars/basin/commit/c5e425a0e835dbf47ff7fc964f97ff966fa6fcec)), closes [#36](https://github.com/jolars/basin/issues/36)
+- add `scratch` buffer for simplex state ([`5255d75`](https://github.com/jolars/basin/commit/5255d750ad932bfce35d51f4fc6f57be21f19eac))
+- add `core::observer::Observe<S>` trait ([`6b740ac`](https://github.com/jolars/basin/commit/6b740ac2e03a041876e392ad35ce5a04d0e371b2))
+- **solvers:** add vanilla mini-batch SGD solver ([`916fa7f`](https://github.com/jolars/basin/commit/916fa7f28aeb112df402418bb1f05be7104b23f4))
+
+### Performance Improvements
+- **solvers:** reduce allocations in Nelder-Mead ([`514c4a0`](https://github.com/jolars/basin/commit/514c4a07275211af8325841061f29f66797f57bc))
+- speed up `SGD::next_iter()` ([`b9fa041`](https://github.com/jolars/basin/commit/b9fa041b206dda373a4ef5cf980a415816ca4538))
+
 ## [0.9.0](https://github.com/jolars/basin/compare/v0.8.0...v0.9.0) (2026-05-31)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "faer",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bumpalo"
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "competitor-bench"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -680,9 +680,9 @@ checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -935,9 +935,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "loom"

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM / GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.10.0](https://github.com/jolars/basin/compare/v0.9.0...v0.10.0) (2026-06-02)

### Breaking changes
- add `best_cost`, `best_iter` and friends to `BasicState` ([`c5e425a`](https://github.com/jolars/basin/commit/c5e425a0e835dbf47ff7fc964f97ff966fa6fcec)), closes [#36](https://github.com/jolars/basin/issues/36)

### Features
- **solvers:** add `DeInject` solver ([`ca34b5c`](https://github.com/jolars/basin/commit/ca34b5c88e79d3b6420a9e00af277704e6b0ef85))
- add `best_cost`, `best_iter` and friends to `BasicState` ([`c5e425a`](https://github.com/jolars/basin/commit/c5e425a0e835dbf47ff7fc964f97ff966fa6fcec)), closes [#36](https://github.com/jolars/basin/issues/36)
- add `scratch` buffer for simplex state ([`5255d75`](https://github.com/jolars/basin/commit/5255d750ad932bfce35d51f4fc6f57be21f19eac))
- add `core::observer::Observe<S>` trait ([`6b740ac`](https://github.com/jolars/basin/commit/6b740ac2e03a041876e392ad35ce5a04d0e371b2))
- **solvers:** add vanilla mini-batch SGD solver ([`916fa7f`](https://github.com/jolars/basin/commit/916fa7f28aeb112df402418bb1f05be7104b23f4))

### Performance Improvements
- **solvers:** reduce allocations in Nelder-Mead ([`514c4a0`](https://github.com/jolars/basin/commit/514c4a07275211af8325841061f29f66797f57bc))
- speed up `SGD::next_iter()` ([`b9fa041`](https://github.com/jolars/basin/commit/b9fa041b206dda373a4ef5cf980a415816ca4538))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).