### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ca34b5c88e79d3b6420a9e00af277704e6b0ef85",
+  "baseline-sha": "e45b6178bc5f2a47c686d4708e2414e55e6a28cf",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.10.0",
-      "tag": "v0.10.0"
+      "version": "0.11.0",
+      "tag": "v0.11.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.11.0](https://github.com/jolars/basin/compare/v0.10.0...v0.11.0) (2026-06-07)
+
+### Breaking changes
+- move CMA-ES distribution into CmaEsState (B8) ([`9c48802`](https://github.com/jolars/basin/commit/9c48802778ae3901dfdaa8bd4f4a45ee36c53714))
+- mark growable public enums #[non_exhaustive] ([`8254680`](https://github.com/jolars/basin/commit/82546800198e4b70d455362e26848808069060f9))
+
+### Features
+- add per-backend QuasiNewtonState aliases (B4) ([`295fe75`](https://github.com/jolars/basin/commit/295fe7516daafe80fa6b9cbe79150445946de5e4))
+- add `new()` to NelderMead and deprecate `standard()` ([`7d3a7b2`](https://github.com/jolars/basin/commit/7d3a7b26fbaf9b47afd980fe0b8e7c40582ebc28))
+- move CMA-ES distribution into CmaEsState (B8) ([`9c48802`](https://github.com/jolars/basin/commit/9c48802778ae3901dfdaa8bd4f4a45ee36c53714))
+- mark growable public enums #[non_exhaustive] ([`8254680`](https://github.com/jolars/basin/commit/82546800198e4b70d455362e26848808069060f9))
+
+### Performance Improvements
+- parallelize population-based solvers ([`74f281d`](https://github.com/jolars/basin/commit/74f281d953a465911768af0e8251d40ba25877b9))
+- parallelize numerical gradients, jacobians, hessians ([`9fa265a`](https://github.com/jolars/basin/commit/9fa265ae8298da11fce1f6339f7f61da0215a6a0))
+
 ## [0.10.0](https://github.com/jolars/basin/compare/v0.9.0...v0.10.0) (2026-06-02)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "faer",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "competitor-bench"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -937,9 +937,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loom"

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM / GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.11.0](https://github.com/jolars/basin/compare/v0.10.0...v0.11.0) (2026-06-07)

### Breaking changes
- move CMA-ES distribution into CmaEsState (B8) ([`9c48802`](https://github.com/jolars/basin/commit/9c48802778ae3901dfdaa8bd4f4a45ee36c53714))
- mark growable public enums #[non_exhaustive] ([`8254680`](https://github.com/jolars/basin/commit/82546800198e4b70d455362e26848808069060f9))

### Features
- add per-backend QuasiNewtonState aliases (B4) ([`295fe75`](https://github.com/jolars/basin/commit/295fe7516daafe80fa6b9cbe79150445946de5e4))
- add `new()` to NelderMead and deprecate `standard()` ([`7d3a7b2`](https://github.com/jolars/basin/commit/7d3a7b26fbaf9b47afd980fe0b8e7c40582ebc28))
- move CMA-ES distribution into CmaEsState (B8) ([`9c48802`](https://github.com/jolars/basin/commit/9c48802778ae3901dfdaa8bd4f4a45ee36c53714))
- mark growable public enums #[non_exhaustive] ([`8254680`](https://github.com/jolars/basin/commit/82546800198e4b70d455362e26848808069060f9))

### Performance Improvements
- parallelize population-based solvers ([`74f281d`](https://github.com/jolars/basin/commit/74f281d953a465911768af0e8251d40ba25877b9))
- parallelize numerical gradients, jacobians, hessians ([`9fa265a`](https://github.com/jolars/basin/commit/9fa265ae8298da11fce1f6339f7f61da0215a6a0))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).