### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "e45b6178bc5f2a47c686d4708e2414e55e6a28cf",
+  "baseline-sha": "f4bc28491cf977bbb9d2496ccaf4a33431fa6bfe",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.11.0",
-      "tag": "v0.11.0"
+      "version": "0.12.0",
+      "tag": "v0.12.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.12.0](https://github.com/jolars/basin/compare/v0.11.0...v0.12.0) (2026-06-09)
+
+### Breaking changes
+- add `NllsState` and `ScalarState` ([`7dfdaff`](https://github.com/jolars/basin/commit/7dfdaffc55fbef5e50271f4f6006d3de5743f427))
+- **math:** curate the public math-tier surface for 1.0 (C2) ([`9411824`](https://github.com/jolars/basin/commit/9411824d603e4c14293cdc4cfb4ddb4c0fd62bca))
+
+### Features
+- **solver:** add `GoldenSection` 1D solver ([`f4bc284`](https://github.com/jolars/basin/commit/f4bc28491cf977bbb9d2496ccaf4a33431fa6bfe))
+- add `NllsState` and `ScalarState` ([`7dfdaff`](https://github.com/jolars/basin/commit/7dfdaffc55fbef5e50271f4f6006d3de5743f427))
+- add `TerminationCriterion::reset` hook for safe inner-criteria reuse ([`3e56bae`](https://github.com/jolars/basin/commit/3e56baea01695e2891c296556440efd4f4793dea))
+
 ## [0.11.0](https://github.com/jolars/basin/compare/v0.10.0...v0.11.0) (2026-06-07)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "criterion",
  "faer",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "competitor-bench"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -895,13 +895,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1884,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1897,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1907,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1920,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM / GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [0.12.0](https://github.com/jolars/basin/compare/v0.11.0...v0.12.0) (2026-06-09)

### Breaking changes
- add `NllsState` and `ScalarState` ([`7dfdaff`](https://github.com/jolars/basin/commit/7dfdaffc55fbef5e50271f4f6006d3de5743f427))
- **math:** curate the public math-tier surface for 1.0 (C2) ([`9411824`](https://github.com/jolars/basin/commit/9411824d603e4c14293cdc4cfb4ddb4c0fd62bca))

### Features
- **solver:** add `GoldenSection` 1D solver ([`f4bc284`](https://github.com/jolars/basin/commit/f4bc28491cf977bbb9d2496ccaf4a33431fa6bfe))
- add `NllsState` and `ScalarState` ([`7dfdaff`](https://github.com/jolars/basin/commit/7dfdaffc55fbef5e50271f4f6006d3de5743f427))
- add `TerminationCriterion::reset` hook for safe inner-criteria reuse ([`3e56bae`](https://github.com/jolars/basin/commit/3e56baea01695e2891c296556440efd4f4793dea))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).