### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,11 +1,11 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "f4bc28491cf977bbb9d2496ccaf4a33431fa6bfe",
+  "baseline-sha": "53e189bb83ccdb9b96ea46d11d1890d384d4f8a7",
   "release-targets": [
     {
       "path": ".",
-      "version": "0.12.0",
-      "tag": "v0.12.0"
+      "version": "1.0.0",
+      "tag": "v1.0.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.0.0](https://github.com/jolars/basin/compare/v0.12.0...v1.0.0) (2026-06-10)
+
+### Breaking changes
+- remove deprecated solver aliases and builder shims ([`d3ebd30`](https://github.com/jolars/basin/commit/d3ebd309edc1c680b4ed1fb593645224fa593193))
+
+### Features
+- **backends:** enable `Vec<F>` backend on LM and GaussNewton ([`6735709`](https://github.com/jolars/basin/commit/6735709adcc9c1c1d48a217ffedd922c4e441c70))
+- remove deprecated solver aliases and builder shims ([`d3ebd30`](https://github.com/jolars/basin/commit/d3ebd309edc1c680b4ed1fb593645224fa593193))
+- **solvers:** add `BrentDerivative` 1D solver ([`161cb67`](https://github.com/jolars/basin/commit/161cb6709cb4e981c60d7ff744c90273762dc619))
+
+### Bug Fixes
+- **math:** clear panic on non-finite bounds in sample_uniform_box ([`53e189b`](https://github.com/jolars/basin/commit/53e189bb83ccdb9b96ea46d11d1890d384d4f8a7)), closes [#41](https://github.com/jolars/basin/issues/41)
+
+### Performance Improvements
+- fuse cost and gradient computations in More-Thuente line search ([`3dc0201`](https://github.com/jolars/basin/commit/3dc02018ebc70b6392896c22e5ebd75b26824cf0))
+
 ## [0.12.0](https://github.com/jolars/basin/compare/v0.11.0...v0.12.0) (2026-06-09)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "0.12.0"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "faer",
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "0.12.0"
+version = "1.0.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "competitor-bench"
-version = "0.12.0"
+version = "1.0.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -1496,9 +1496,9 @@ checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1519,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc_version"
@@ -2066,18 +2066,18 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "0.12.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "0.12.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM / GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "0.12.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [1.0.0](https://github.com/jolars/basin/compare/v0.12.0...v1.0.0) (2026-06-10)

### Breaking changes
- remove deprecated solver aliases and builder shims ([`d3ebd30`](https://github.com/jolars/basin/commit/d3ebd309edc1c680b4ed1fb593645224fa593193))

### Features
- **backends:** enable `Vec<F>` backend on LM and GaussNewton ([`6735709`](https://github.com/jolars/basin/commit/6735709adcc9c1c1d48a217ffedd922c4e441c70))
- remove deprecated solver aliases and builder shims ([`d3ebd30`](https://github.com/jolars/basin/commit/d3ebd309edc1c680b4ed1fb593645224fa593193))
- **solvers:** add `BrentDerivative` 1D solver ([`161cb67`](https://github.com/jolars/basin/commit/161cb6709cb4e981c60d7ff744c90273762dc619))

### Bug Fixes
- **math:** clear panic on non-finite bounds in sample_uniform_box ([`53e189b`](https://github.com/jolars/basin/commit/53e189bb83ccdb9b96ea46d11d1890d384d4f8a7)), closes [#41](https://github.com/jolars/basin/issues/41)

### Performance Improvements
- fuse cost and gradient computations in More-Thuente line search ([`3dc0201`](https://github.com/jolars/basin/commit/3dc02018ebc70b6392896c22e5ebd75b26824cf0))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).