### PR TITLE
feat(solvers): add MADS (OrthoMADS) derivative-free solver

### DIFF
--- a/.claude/rules/constraints.md
+++ b/.claude/rules/constraints.md
@@ -55,7 +55,12 @@ sibling traits (see below):
   vector-valued `c`, exposing `constraints(x)` + `num_constraints()`) — kept
   feasible by an *exact-penalty merit function with a geometry/acceptance test*
   (Φ = F + μ·[maxᵢ cᵢ]₊), no projection, no barrier, no multipliers. Used by
-  the derivative-free `Cobyla` (`src/solver/cobyla.rs`). Unlike the three other
+  the derivative-free `Cobyla` (`src/solver/cobyla.rs`). Also consumed by
+  `Mads<Constrained>` (`Mads::constrained()`, `src/solver/mads.rs`), which keeps
+  the *same trait* feasible by a **different mechanism** — the *progressive
+  barrier* (Audet & Dennis 2009): an aggregate violation `h(x) = Σⱼ max(cⱼ, 0)²`
+  and a threshold driven to zero around two incumbents. So the consumer↔mechanism
+  map is many-to-many; the trait is just the data contract. Unlike the three other
   kinds the constraint is a **function evaluated at the iterate**, not
   matrix/vector data, so the trait carries an evaluator rather than `a()`/`b()`
   accessors. Sign convention is `cᵢ(x) ≤ 0` (feasible), matching the

--- a/TODO.md
+++ b/TODO.md
@@ -22,12 +22,16 @@ the previous lands.
       hand-rolled `DenseMatrix`), nalgebra, faer, and `ndarray` (`Array2`) ---
       so both methods run on the default backend with no external LA crate.
       Nonlinear inequalities `c(x) ≤ 0` shipped
-      (`NonlinearInequalityConstraints`, consumed directly by `Cobyla` --- the
+      (`NonlinearInequalityConstraints`, consumed by `Cobyla` --- the
       derivative-free COBYLA, Powell 1994, ported from PRIMA --- via an
-      L-infinity exact-penalty merit function; function-valued so it needs only
-      vector-tier ops, hence all backends + wasm). Remaining: phase-1
-      feasibility (the barrier needs a strictly feasible start today; the
-      augmented Lagrangian and COBYLA do not); a framework-level
+      L-infinity exact-penalty merit function, and by `Mads<Constrained>`
+      (`Mads::constrained()`) via the *progressive barrier* (Audet & Dennis
+      2009, an aggregate violation `h(x) = Σⱼ max(cⱼ, 0)²` and a threshold driven
+      to zero around two incumbents; tolerates an infeasible start);
+      function-valued so it needs only vector-tier ops, hence all backends +
+      wasm). Remaining: phase-1 feasibility (the barrier needs a strictly
+      feasible start today; the augmented Lagrangian, COBYLA, and the MADS
+      progressive barrier do not); a framework-level
       `FeasibilityTolerance` once a 2nd nonlinear/equality-constrained solver
       justifies it (tenet 3); nonlinear *equality* constraints; and a
       `NonlinearConstraints` aggregator (nonlinear + linear + box, PRIMA's full

--- a/crates/basin-wasm/src/lib.rs
+++ b/crates/basin-wasm/src/lib.rs
@@ -26,8 +26,8 @@ use basin::solver::lbfgs::{Lbfgs, Unbounded as LbfgsUnbounded};
 use basin::{
     Backtracking, BasicPopulationState, BasicSimplexState, BasicState, BoxConstraints, CmaEs,
     CmaEsState, Constant, CostFunction, De, DenseMatrix, Executor, FiniteDiff, Gradient,
-    GradientDescent, LbfgsState, MoreThuente, NelderMead, PopulationState, RandomSearch, Ssga,
-    State, StepOutcome, Stepper, TerminationReason,
+    GradientDescent, LbfgsState, Mads, MadsState, MoreThuente, NelderMead, PopulationState,
+    RandomSearch, Ssga, State, StepOutcome, Stepper, TerminationReason,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -68,6 +68,7 @@ pub enum SolverKind {
     De = 4,
     RandomSearch = 5,
     Ssga = 6,
+    Mads = 7,
 }
 
 /// Solver-specific knobs, marshaled across the wasm boundary as a single
@@ -312,6 +313,7 @@ enum Inner {
         Stepper<Problem2D, BasicState<Vec<f64>>, GradientDescent<Backtracking, Vec<f64>>>,
     ),
     NelderMead(Stepper<Problem2D, BasicSimplexState<Vec<f64>>, NelderMead>),
+    Mads(Stepper<Problem2D, MadsState<Vec<f64>>, Mads>),
     // Boxed: `LbfgsState` carries the limited-memory history buffers, so
     // this variant is several times larger than the others — boxing keeps
     // `Inner` small (clippy::large_enum_variant). Auto-deref means the
@@ -332,6 +334,7 @@ impl Inner {
             Self::GdConstant(s) => s.step().unwrap(),
             Self::GdBacktracking(s) => s.step().unwrap(),
             Self::NelderMead(s) => s.step().unwrap(),
+            Self::Mads(s) => s.step().unwrap(),
             Self::Lbfgs(s) => s.step().unwrap(),
             Self::CmaEs(s) => s.step().unwrap(),
             Self::De(s) => s.step().unwrap(),
@@ -349,6 +352,7 @@ impl Inner {
             Self::GdConstant(s) => s.state().param(),
             Self::GdBacktracking(s) => s.state().param(),
             Self::NelderMead(s) => s.state().param(),
+            Self::Mads(s) => s.state().param(),
             Self::Lbfgs(s) => s.state().param(),
             Self::CmaEs(s) => s.state().param(),
             Self::De(s) => s.state().param(),
@@ -363,6 +367,7 @@ impl Inner {
             Self::GdConstant(s) => s.state().cost(),
             Self::GdBacktracking(s) => s.state().cost(),
             Self::NelderMead(s) => s.state().cost(),
+            Self::Mads(s) => s.state().cost(),
             Self::Lbfgs(s) => s.state().cost(),
             Self::CmaEs(s) => s.state().cost(),
             Self::De(s) => s.state().cost(),
@@ -577,6 +582,14 @@ impl Run {
                 .into_stepper()
                 .unwrap();
                 Inner::NelderMead(stepper)
+            }
+            SolverKind::Mads => {
+                let stepper =
+                    Executor::new(p, Mads::new(), MadsState::<Vec<f64>>::new(initial.clone()))
+                        .max_iter(max_iter as u64)
+                        .into_stepper()
+                        .unwrap();
+                Inner::Mads(stepper)
             }
             SolverKind::Lbfgs => {
                 // `m_capacity` asserts `>= 1`; clamp so a stray `0` from

--- a/crates/basin/src/core/state.rs
+++ b/crates/basin/src/core/state.rs
@@ -28,6 +28,8 @@ pub mod cobyla;
 pub mod lbfgs;
 /// LINCOA solver state (`LincoaState`).
 pub mod lincoa;
+/// MADS solver state (`MadsState`).
+pub mod mads;
 /// NEWUOA solver state (`NewuoaState`).
 pub mod newuoa;
 /// Nonlinear least-squares state (`NllsState`).
@@ -42,6 +44,7 @@ pub use cma_es::CmaEsState;
 pub use cobyla::CobylaState;
 pub use lbfgs::LbfgsState;
 pub use lincoa::LincoaState;
+pub use mads::{ConstrainedMadsState, MadsState};
 pub use newuoa::NewuoaState;
 pub use nlls::NllsState;
 pub use scalar::ScalarState;
@@ -355,6 +358,20 @@ pub trait PopulationState: State {
 pub trait RhoState: State {
     /// The current trust-region radius `ρ`.
     fn rho(&self) -> Self::Float;
+}
+
+/// State that carries a mesh adaptive direct search **poll size** `Δᵖ` and mesh
+/// index `ℓ`, the minimum shape the
+/// [`MeshTolerance`](crate::core::termination::MeshTolerance) criterion binds on
+/// (tenet 3). Implemented by [`MadsState`]; the poll size shrinks
+/// (≈ halving on unsuccessful iterations) toward a configured floor, and the
+/// criterion fires once it reaches that floor.
+pub trait MeshState: State {
+    /// The current poll size `Δᵖ` (bounds the distance from the incumbent to the
+    /// poll trial points).
+    fn poll_size(&self) -> Self::Float;
+    /// The current mesh index `ℓ` (OrthoMADS eq. (1)).
+    fn mesh_index(&self) -> i32;
 }
 
 /// Default state for single-iterate solvers (gradient descent,

--- a/crates/basin/src/core/state/mads.rs
+++ b/crates/basin/src/core/state/mads.rs
@@ -1,0 +1,360 @@
+//! MADS solver state.
+//!
+//! A single-iterate state for the mesh adaptive direct search solver
+//! [`Mads`](crate::solver::Mads). It carries the current incumbent (the best
+//! feasible point found so far, since MADS only ever moves to an improving mesh
+//! point) and the current **poll size** `Δᵖ`, which the natural-convergence
+//! criterion [`MeshTolerance`](crate::core::termination::MeshTolerance) binds on.
+//!
+//! The mesh/poll bookkeeping (the integer mesh index `ℓ`, the Halton-index
+//! schedule, the incumbent in flat scratch) lives on the **solver** struct
+//! (`Mads`'s `MadsWork`), not here — the same split the Powell-family DFO solvers
+//! use. So [`MadsState`] is generic over the parameter vector `V` only: the
+//! direction algebra is internal `Vec<f64>`/`Vec<i64>` scratch and needs no
+//! `linalg`-tier ops from `V`.
+//!
+//! # Current vs best
+//!
+//! MADS's reported iterate is monotone non-increasing by construction (it accepts
+//! only improving mesh points), so [`best_param`](State::best_param) /
+//! [`best_cost`](State::best_cost) coincide with the current iterate at every
+//! check, like the sorted-simplex / Powell-DFO shapes.
+
+use crate::core::math::Scalar;
+use crate::core::problem::EvalCounts;
+use crate::core::state::{CountsMirror, MeshState, State};
+
+/// Solver state for [`Mads`](crate::solver::Mads).
+///
+/// Construct with [`new`](Self::new) from the starting point; the solver
+/// evaluates it and seeds the cost / poll size in
+/// [`Solver::init`](crate::core::solver::Solver::init).
+///
+/// The scalar `F` defaults to `f64` so call sites resolve unchanged.
+pub struct MadsState<V, F = f64> {
+    /// Current incumbent — the best feasible point found so far. Initially the
+    /// user's starting point.
+    pub(crate) param: V,
+    /// `f(param)`. `None` before [`Solver::init`](crate::core::solver::Solver::init).
+    pub(crate) cost: Option<F>,
+    /// Current poll size `Δᵖ` — `+∞` before
+    /// [`Solver::init`](crate::core::solver::Solver::init) seeds it. Shrinks
+    /// (≈ halving on unsuccessful iterations) toward the configured floor.
+    /// [`MeshTolerance`](crate::core::termination::MeshTolerance) reads it.
+    pub(crate) poll_size: F,
+    /// Current mesh index `ℓ` (OrthoMADS eq. (1)): `ℓ−1` on success, `ℓ+1` on
+    /// failure. `0` before init.
+    pub(crate) mesh_index: i32,
+
+    // --- best evaluated point (coincides with the current iterate) ---
+    pub(crate) best_param: Option<V>,
+    pub(crate) best_cost: F,
+    pub(crate) best_iter: u64,
+    pub(crate) best_cost_evals: u64,
+
+    // --- counters ---
+    pub(crate) iter: u64,
+    pub(crate) cost_evals: u64,
+}
+
+impl<V, F: Scalar> MadsState<V, F> {
+    /// Build an initial MADS state at the starting point `x0`. The solver
+    /// evaluates `x0` and fills the cost / poll size in
+    /// [`Solver::init`](crate::core::solver::Solver::init).
+    pub fn new(x0: V) -> Self {
+        Self {
+            param: x0,
+            cost: None,
+            poll_size: F::infinity(),
+            mesh_index: 0,
+            best_param: None,
+            best_cost: F::infinity(),
+            best_iter: 0,
+            best_cost_evals: 0,
+            iter: 0,
+            cost_evals: 0,
+        }
+    }
+
+    /// The current poll size `Δᵖ`. `+∞` before
+    /// [`Solver::init`](crate::core::solver::Solver::init); thereafter shrinks
+    /// toward the configured floor.
+    pub fn poll_size(&self) -> F {
+        self.poll_size
+    }
+
+    /// The current mesh index `ℓ` (OrthoMADS eq. (1)).
+    pub fn mesh_index(&self) -> i32 {
+        self.mesh_index
+    }
+}
+
+impl<V: Clone, F: Scalar> State for MadsState<V, F> {
+    type Param = V;
+    type Float = F;
+
+    fn iter(&self) -> u64 {
+        self.iter
+    }
+
+    fn increment_iter(&mut self) {
+        self.iter += 1;
+    }
+
+    fn cost_evals(&self) -> u64 {
+        self.cost_evals
+    }
+
+    fn param(&self) -> &V {
+        &self.param
+    }
+
+    /// Cost at the current [`param`](State::param).
+    ///
+    /// # Panics
+    ///
+    /// Panics if read before
+    /// [`Solver::init`](crate::core::solver::Solver::init) has evaluated the
+    /// starting point. By contract the executor calls `init` before any
+    /// termination check, so reads from criteria and from
+    /// [`OptimizationResult`](crate::core::executor::OptimizationResult) are
+    /// safe.
+    fn cost(&self) -> F {
+        self.cost
+            .expect("MadsState::cost read before Solver::init evaluated the start point")
+    }
+
+    fn best_param(&self) -> &V {
+        self.best_param
+            .as_ref()
+            .expect("MadsState::best_param read before Solver::init populated it")
+    }
+
+    fn best_cost(&self) -> F {
+        self.best_cost
+    }
+
+    fn best_iter(&self) -> u64 {
+        self.best_iter
+    }
+
+    fn best_cost_evals(&self) -> u64 {
+        self.best_cost_evals
+    }
+
+    fn update_best(&mut self) {
+        if let Some(cost) = self.cost {
+            if self.best_param.is_none() || cost < self.best_cost {
+                self.best_param = Some(self.param.clone());
+                self.best_cost = cost;
+                self.best_iter = self.iter;
+                self.best_cost_evals = self.cost_evals;
+            }
+        }
+    }
+
+    fn reset_best(&mut self) {
+        self.best_param = None;
+        self.best_cost = F::infinity();
+        self.best_iter = 0;
+        self.best_cost_evals = 0;
+    }
+}
+
+impl<V: Clone, F: Scalar> MeshState for MadsState<V, F> {
+    fn poll_size(&self) -> F {
+        self.poll_size
+    }
+
+    fn mesh_index(&self) -> i32 {
+        self.mesh_index
+    }
+}
+
+impl<V, F> CountsMirror for MadsState<V, F>
+where
+    MadsState<V, F>: State,
+{
+    fn mirror(&mut self, delta: &EvalCounts) {
+        // Derivative-free: MADS only ever calls the cost function, so every unit
+        // of work folds into the single `cost_evals` counter (the same rule as
+        // the other derivative-free states).
+        self.cost_evals = delta.total_work();
+    }
+}
+
+/// Solver state for the **constrained** MADS variant
+/// (`Mads<Constrained>`), which handles nonlinear inequality constraints
+/// `c(x) ≤ 0` by the progressive barrier (see
+/// [`Mads::constrained`](crate::Mads::constrained)).
+///
+/// It carries the same poll/mesh bookkeeping as [`MadsState`] plus the
+/// **aggregate constraint violation** `h(x) = Σⱼ max(cⱼ(x), 0)²` at the reported
+/// incumbent ([`constraint_violation`](Self::constraint_violation); `0` ⇔
+/// feasible). Construct it with [`new`](Self::new) from the starting point — an
+/// **infeasible start is allowed** (the progressive barrier relaxes its way to
+/// feasibility).
+///
+/// # Current vs best
+///
+/// Unlike the unconstrained [`MadsState`], the reported objective is **not**
+/// monotone — a newly found feasible point can have a higher `f` than a prior
+/// infeasible incumbent. The solver's progressive-barrier driver owns the
+/// incumbent selection, so [`update_best`](State::update_best) mirrors the
+/// current iterate unconditionally (the same rule
+/// [`CobylaState`](crate::CobylaState) uses), rather than ranking by `cost`.
+///
+/// The scalar `F` defaults to `f64` so call sites resolve unchanged.
+pub struct ConstrainedMadsState<V, F = f64> {
+    /// Current reported incumbent — the best feasible point if one has been
+    /// found, else the best infeasible point within the barrier threshold.
+    pub(crate) param: V,
+    /// `f(param)`. `None` before [`Solver::init`](crate::core::solver::Solver::init).
+    pub(crate) cost: Option<F>,
+    /// Aggregate constraint violation `h(param)` at the reported incumbent.
+    /// `+∞` before init; `0` once the incumbent is feasible.
+    pub(crate) constraint_violation: F,
+    /// Current poll size `Δᵖ` — `+∞` before init.
+    pub(crate) poll_size: F,
+    /// Current mesh index `ℓ` (OrthoMADS eq. (1)). `0` before init.
+    pub(crate) mesh_index: i32,
+
+    // --- best evaluated point (mirrors the current incumbent) ---
+    pub(crate) best_param: Option<V>,
+    pub(crate) best_cost: F,
+    pub(crate) best_iter: u64,
+    pub(crate) best_cost_evals: u64,
+
+    // --- counters ---
+    pub(crate) iter: u64,
+    pub(crate) cost_evals: u64,
+}
+
+impl<V, F: Scalar> ConstrainedMadsState<V, F> {
+    /// Build an initial constrained-MADS state at the starting point `x0` (which
+    /// may be infeasible). The solver evaluates `x0`'s cost and violation and
+    /// fills the poll size in [`Solver::init`](crate::core::solver::Solver::init).
+    pub fn new(x0: V) -> Self {
+        Self {
+            param: x0,
+            cost: None,
+            constraint_violation: F::infinity(),
+            poll_size: F::infinity(),
+            mesh_index: 0,
+            best_param: None,
+            best_cost: F::infinity(),
+            best_iter: 0,
+            best_cost_evals: 0,
+            iter: 0,
+            cost_evals: 0,
+        }
+    }
+
+    /// The aggregate constraint violation `h = Σⱼ max(cⱼ, 0)²` at the reported
+    /// incumbent. `0` once the incumbent is feasible; `+∞` before
+    /// [`Solver::init`](crate::core::solver::Solver::init).
+    pub fn constraint_violation(&self) -> F {
+        self.constraint_violation
+    }
+
+    /// The current poll size `Δᵖ`.
+    pub fn poll_size(&self) -> F {
+        self.poll_size
+    }
+
+    /// The current mesh index `ℓ` (OrthoMADS eq. (1)).
+    pub fn mesh_index(&self) -> i32 {
+        self.mesh_index
+    }
+}
+
+impl<V: Clone, F: Scalar> State for ConstrainedMadsState<V, F> {
+    type Param = V;
+    type Float = F;
+
+    fn iter(&self) -> u64 {
+        self.iter
+    }
+
+    fn increment_iter(&mut self) {
+        self.iter += 1;
+    }
+
+    fn cost_evals(&self) -> u64 {
+        self.cost_evals
+    }
+
+    fn param(&self) -> &V {
+        &self.param
+    }
+
+    /// Cost at the current [`param`](State::param).
+    ///
+    /// # Panics
+    ///
+    /// Panics if read before
+    /// [`Solver::init`](crate::core::solver::Solver::init) has evaluated the
+    /// starting point.
+    fn cost(&self) -> F {
+        self.cost
+            .expect("ConstrainedMadsState::cost read before Solver::init evaluated the start point")
+    }
+
+    fn best_param(&self) -> &V {
+        self.best_param
+            .as_ref()
+            .expect("ConstrainedMadsState::best_param read before Solver::init populated it")
+    }
+
+    fn best_cost(&self) -> F {
+        self.best_cost
+    }
+
+    fn best_iter(&self) -> u64 {
+        self.best_iter
+    }
+
+    fn best_cost_evals(&self) -> u64 {
+        self.best_cost_evals
+    }
+
+    /// Mirror the current incumbent unconditionally — the progressive-barrier
+    /// driver owns incumbent selection, and the reported `cost` is not monotone
+    /// across the feasibility transition, so a `cost`-ranked best would be wrong.
+    fn update_best(&mut self) {
+        if let Some(cost) = self.cost {
+            self.best_param = Some(self.param.clone());
+            self.best_cost = cost;
+            self.best_iter = self.iter;
+            self.best_cost_evals = self.cost_evals;
+        }
+    }
+
+    fn reset_best(&mut self) {
+        self.best_param = None;
+        self.best_cost = F::infinity();
+        self.best_iter = 0;
+        self.best_cost_evals = 0;
+    }
+}
+
+impl<V: Clone, F: Scalar> MeshState for ConstrainedMadsState<V, F> {
+    fn poll_size(&self) -> F {
+        self.poll_size
+    }
+
+    fn mesh_index(&self) -> i32 {
+        self.mesh_index
+    }
+}
+
+impl<V, F> CountsMirror for ConstrainedMadsState<V, F>
+where
+    ConstrainedMadsState<V, F>: State,
+{
+    fn mirror(&mut self, delta: &EvalCounts) {
+        // Derivative-free: every unit of work (cost + constraint evals) folds
+        // into the single `cost_evals` counter.
+        self.cost_evals = delta.total_work();
+    }
+}

--- a/crates/basin/src/core/termination.rs
+++ b/crates/basin/src/core/termination.rs
@@ -7,7 +7,7 @@ use web_time::{Duration, Instant};
 
 use crate::core::constraint::BoxConstraints;
 use crate::core::math::{ClampInPlace, NormInfinity, NormSquared, Scalar, ScaledAdd, VectorLen};
-use crate::core::state::{CmaEsState, GradientState, RhoState, SimplexState, State};
+use crate::core::state::{CmaEsState, GradientState, MeshState, RhoState, SimplexState, State};
 
 /// Why the executor stopped. Returned on
 /// [`OptimizationResult::reason`](crate::core::executor::OptimizationResult::reason)
@@ -53,6 +53,8 @@ pub enum TerminationReason {
     CmaEsTolerance,
     /// NEWUOA trust-region radius reached the configured floor: `ρ ≤ rho_end`.
     RhoTolerance,
+    /// MADS poll size reached the configured floor: `Δᵖ ≤ poll_size_min`.
+    MeshTolerance,
     /// Wall-clock time limit reached.
     MaxTime,
     /// Solver determined it has converged (e.g. fixed point reached).
@@ -682,6 +684,35 @@ where
 {
     fn check(&mut self, state: &S) -> Option<TerminationReason> {
         (state.rho() <= self.rho_end).then_some(TerminationReason::RhoTolerance)
+    }
+}
+
+/// Stop a MADS solver once its poll size `Δᵖ` shrinks to `poll_size_min`.
+///
+/// Binds on any [`MeshState`] ([`MadsState`](crate::core::state::MadsState)).
+/// This is the natural convergence test of MADS: [`Mads`](crate::solver::Mads)
+/// already self-terminates when `Δᵖ` reaches the floor it was configured with,
+/// so this criterion is mainly useful to stop **early** at a coarser poll size
+/// than the configured floor — e.g. a quick low-accuracy solve. The threshold
+/// should satisfy `poll_size_min ≥` the solver's configured floor to fire first.
+pub struct MeshTolerance<F = f64> {
+    poll_size_min: F,
+}
+
+impl<F> MeshTolerance<F> {
+    /// New criterion firing at `Δᵖ ≤ poll_size_min`.
+    pub fn new(poll_size_min: F) -> Self {
+        Self { poll_size_min }
+    }
+}
+
+impl<S> TerminationCriterion<S> for MeshTolerance<S::Float>
+where
+    S: MeshState,
+    S::Float: Scalar,
+{
+    fn check(&mut self, state: &S) -> Option<TerminationReason> {
+        (state.poll_size() <= self.poll_size_min).then_some(TerminationReason::MeshTolerance)
     }
 }
 

--- a/crates/basin/src/lib.rs
+++ b/crates/basin/src/lib.rs
@@ -147,15 +147,16 @@ pub use crate::core::state::FaerQuasiNewtonState;
 pub use crate::core::state::NalgebraQuasiNewtonState;
 pub use crate::core::state::{
     BasicPopulationState, BasicSimplexState, BasicState, BobyqaState, CmaEsState, CobylaState,
-    CountsMirror, GradientState, IntoInitialSimplex, LbfgsState, LincoaState, NewuoaState,
-    NllsState, PopulationState, RhoState, ScalarGradientState, ScalarState, SimplexState, State,
+    ConstrainedMadsState, CountsMirror, GradientState, IntoInitialSimplex, LbfgsState, LincoaState,
+    MadsState, MeshState, NewuoaState, NllsState, PopulationState, RhoState, ScalarGradientState,
+    ScalarState, SimplexState, State,
 };
 pub use crate::core::state::{DenseQuasiNewtonState, QuasiNewtonState};
 pub use crate::core::termination::{
     CmaEsTolerance, CostTolerance, GradientTolerance, MaxCostEvals, MaxGradientEvals, MaxIter,
-    MaxTime, NoImprovement, ParamTolerance, ProjectedGradientTolerance, RelativeCostTolerance,
-    RelativeGradientTolerance, RelativeParamTolerance, RhoTolerance, SimplexTolerance, TargetCost,
-    TerminationCriterion, TerminationReason,
+    MaxTime, MeshTolerance, NoImprovement, ParamTolerance, ProjectedGradientTolerance,
+    RelativeCostTolerance, RelativeGradientTolerance, RelativeParamTolerance, RhoTolerance,
+    SimplexTolerance, TargetCost, TerminationCriterion, TerminationReason,
 };
 pub use crate::line_search::{Backtracking, Constant, LineSearch, MoreThuente, Wolfe};
 pub use crate::solver::Bfgs;
@@ -163,6 +164,6 @@ pub use crate::solver::lbfgs::{Lbfgs, Lbfgsb};
 pub use crate::solver::{
     AugmentedLagrangianMethod, BarrierMethod, Bobyqa, BoundedCmaEs, BoundedCmaInject, Brent,
     BrentDerivative, ClosureInner, CmaEs, CmaInject, Cobyla, De, DeInject, GaussNewton,
-    GoldenSection, GradientDescent, LevenbergMarquardt, Lincoa, MaLsChCma, MaLsChState,
+    GoldenSection, GradientDescent, LevenbergMarquardt, Lincoa, MaLsChCma, MaLsChState, Mads,
     MemeticInner, NelderMead, Newuoa, ProjectedGradientDescent, RandomSearch, Sgd, Ssga, Trf,
 };

--- a/crates/basin/src/problems.rs
+++ b/crates/basin/src/problems.rs
@@ -47,6 +47,7 @@ pub mod schaffer;
 pub mod sparse_least_squares;
 pub mod spec;
 pub mod sphere;
+pub mod step;
 pub mod styblinski_tang;
 pub mod three_hump_camel;
 pub mod zero;
@@ -96,6 +97,7 @@ pub use sparse_least_squares::{
 };
 pub use spec::{Dimensionality, HasSpec, ProblemSpec, Properties, Reference};
 pub use sphere::{SPHERE_SPEC, Sphere, sphere, sphere_gradient};
+pub use step::{STEP_SPEC, Step, step};
 pub use styblinski_tang::{
     STYBLINSKI_TANG_SPEC, StyblinskiTang, StyblinskiTangBoxed, styblinski_tang,
     styblinski_tang_gradient,
@@ -116,6 +118,7 @@ pub static ALL_SPECS: &[&ProblemSpec] = &[
     &EQUALITY_CONSTRAINED_QUADRATIC_SPEC,
     &MATYAS_SPEC,
     &MCCORMICK_SPEC,
+    &STEP_SPEC,
     &GOLDSTEIN_PRICE_SPEC,
     &POWELL_SINGULAR_SPEC,
     &RASTRIGIN_SPEC,

--- a/crates/basin/src/problems/step.rs
+++ b/crates/basin/src/problems/step.rs
@@ -1,0 +1,168 @@
+//! N-dimensional Step function (De Jong's discontinuous staircase).
+//!
+//! `f(x) = Σᵢ ⌊xᵢ + 0.5⌋²`
+//!
+//! A piecewise-constant, **discontinuous** function: the floor makes it jump
+//! between flat plateaus. The global minimum is `f = 0` on the central cube
+//! `xᵢ ∈ [−0.5, 0.5)`. It is the canonical test for the case where smooth- and
+//! continuity-based methods break down: the Nelder-Mead simplex degenerates on a
+//! plateau (all vertices tie) and stalls, whereas a mesh-based direct search
+//! (MADS) steps down the staircase to the minimum. Cost-only (discontinuous, so
+//! no gradient).
+
+use core::marker::PhantomData;
+
+use super::spec::{Dimensionality, HasSpec, ProblemSpec, Properties, Reference};
+use crate::CostFunction;
+
+/// Evaluates the Step function at `x` (any dimension `≥ 1`).
+pub fn step(x: &[f64]) -> f64 {
+    x.iter().map(|xi| (xi + 0.5).floor().powi(2)).sum()
+}
+
+/// Pre-wrapped Step problem (scalable N-D). Cost-only: the floor makes it
+/// discontinuous, so no `Gradient` impl is provided. Generic over the parameter
+/// backend `P`; the default `P = Vec<f64>` lets you write `Step::default()` for
+/// the common case.
+pub struct Step<P = Vec<f64>>(PhantomData<fn() -> P>);
+
+impl<P> Step<P> {
+    /// Build a freshly typed problem instance. Pair with one of the
+    /// backend-specific impl blocks (Vec, nalgebra, ndarray, faer).
+    pub const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<P> Default for Step<P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Catalogue entry for this problem.
+pub static STEP_SPEC: ProblemSpec = ProblemSpec {
+    name: "Step",
+    dim: Dimensionality::NDimensional { min: 1 },
+    properties: Properties {
+        // Floor ⇒ piecewise constant: discontinuous, non-differentiable.
+        smooth: false,
+        differentiable: false,
+        convex: false,
+        // Flat plateaus everywhere; a single global-minimum cube but not
+        // strictly unimodal.
+        unimodal: false,
+        // Separable sum of per-coordinate floors.
+        separable: true,
+        scalable: true,
+    },
+    references: &[Reference {
+        citation: "Jamil & Yang (2013)",
+        title: "A literature survey of benchmark functions for global optimisation problems",
+        source: "International Journal of Mathematical Modelling and Numerical Optimisation, 4(2), 150–194",
+        doi: Some("10.1504/IJMMNO.2013.055204"),
+        url: Some("https://arxiv.org/abs/1308.4008"),
+    }],
+    description: "Discontinuous staircase f(x) = Σ ⌊xᵢ + 0.5⌋² (De Jong's step \
+                  function). Global minimum 0 on the central cube xᵢ ∈ [−0.5, \
+                  0.5). Piecewise-constant plateaus make it a target for \
+                  direct-search / derivative-free solvers and a trap for the \
+                  Nelder-Mead simplex, which degenerates on a plateau.",
+};
+
+impl<P> HasSpec for Step<P> {
+    const SPEC: &'static ProblemSpec = &STEP_SPEC;
+}
+
+impl CostFunction for Step<Vec<f64>> {
+    type Param = Vec<f64>;
+    type Output = f64;
+    type Error = std::convert::Infallible;
+    fn cost(&self, x: &Vec<f64>) -> Result<f64, std::convert::Infallible> {
+        Ok(step(x))
+    }
+}
+
+#[cfg(feature = "nalgebra")]
+mod nalgebra_impl {
+    use super::{Step, step};
+    use crate::CostFunction;
+    use nalgebra::DVector;
+
+    impl CostFunction for Step<DVector<f64>> {
+        type Param = DVector<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &DVector<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok(step(x.as_slice()))
+        }
+    }
+}
+
+#[cfg(feature = "ndarray")]
+mod ndarray_impl {
+    use super::{Step, step};
+    use crate::CostFunction;
+    use ndarray::Array1;
+
+    impl CostFunction for Step<Array1<f64>> {
+        type Param = Array1<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &Array1<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok(step(x.as_slice().expect("Array1 is contiguous")))
+        }
+    }
+}
+
+#[cfg(feature = "faer")]
+mod faer_impl {
+    use super::Step;
+    use crate::CostFunction;
+    use faer::Col;
+
+    impl CostFunction for Step<Col<f64>> {
+        type Param = Col<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &Col<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok((0..x.nrows()).map(|i| (x[i] + 0.5).floor().powi(2)).sum())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minimum_is_zero_on_central_cube() {
+        assert_eq!(step(&[0.0, 0.0]), 0.0);
+        // Anywhere in [−0.5, 0.5) is the global minimum.
+        assert_eq!(step(&[-0.4, 0.49]), 0.0);
+    }
+
+    #[test]
+    fn known_values_at_simple_points() {
+        // f(2, 2) = ⌊2.5⌋² + ⌊2.5⌋² = 2² + 2² = 8.
+        assert_eq!(step(&[2.0, 2.0]), 8.0);
+        // f(−1.6, 0.0) = ⌊−1.1⌋² + ⌊0.5⌋² = (−2)² + 0² = 4.
+        assert_eq!(step(&[-1.6, 0.0]), 4.0);
+    }
+
+    #[test]
+    fn scalable_dimension() {
+        assert_eq!(step(&[3.0, 3.0, 3.0, 3.0]), 4.0 * 9.0); // ⌊3.5⌋² = 9 each
+    }
+
+    #[test]
+    fn spec_is_wired_up_via_has_spec_trait() {
+        let spec = <Step<Vec<f64>> as HasSpec>::SPEC;
+        assert_eq!(spec.name, "Step");
+        assert!(!spec.properties.smooth);
+        assert!(!spec.properties.differentiable);
+        assert!(spec.properties.separable);
+        assert!(matches!(spec.dim, Dimensionality::NDimensional { min: 1 }));
+        assert!(!spec.references.is_empty());
+    }
+}

--- a/crates/basin/src/solver.rs
+++ b/crates/basin/src/solver.rs
@@ -46,6 +46,9 @@ pub mod lbfgs;
 pub mod levenberg_marquardt;
 /// MA-LSCh-CMA — memetic algorithm with LS chains (inner: CMA-ES).
 pub mod ma_ls_ch_cma;
+/// MADS (Audet & Dennis 2006) — mesh adaptive direct search (deterministic
+/// OrthoMADS instance) for nonsmooth / non-continuous objectives.
+pub mod mads;
 /// Nelder-Mead derivative-free simplex solver.
 pub mod nelder_mead;
 /// NEWUOA (Powell 2006) — model-based derivative-free trust-region solver
@@ -103,6 +106,7 @@ pub use gradient_descent::GradientDescent;
 pub use levenberg_marquardt::LevenbergMarquardt;
 pub use lincoa::Lincoa;
 pub use ma_ls_ch_cma::{MaLsChCma, MaLsChState};
+pub use mads::{Bounded, Constrained, Mads};
 pub use nelder_mead::{NelderMead, Projected, Unbounded};
 pub use newuoa::Newuoa;
 pub use projected_gradient_descent::ProjectedGradientDescent;

--- a/crates/basin/src/solver/mads.rs
+++ b/crates/basin/src/solver/mads.rs
@@ -1,0 +1,542 @@
+// Index-based loops mirror the OrthoMADS exposition (Abramson et al. 2009) and
+// the flat poll/direction arithmetic; the lint is blanket-allowed here.
+#![allow(clippy::needless_range_loop)]
+
+//! MADS (Audet & Dennis 2006) — mesh adaptive direct search, the deterministic
+//! OrthoMADS instance (Abramson, Audet, Dennis & Le Digabel 2009).
+//!
+//! [`Mads`] is a directional direct-search method for **nonsmooth /
+//! non-continuous** objectives, where Nelder-Mead has no convergence theory and
+//! is known to stagnate. Each iteration polls a positive spanning set of `2n`
+//! directions on a shrinking mesh around the incumbent; an improving mesh point
+//! coarsens the mesh, a failed poll refines it. The set of poll directions
+//! becomes asymptotically dense, which gives MADS its Clarke-stationarity
+//! convergence guarantee on nonsmooth functions. It binds [`CostFunction`] only
+//! — no derivatives.
+//!
+//! # Architecture
+//!
+//! This implements the **OrthoMADS** instance: the poll directions are generated
+//! deterministically (no RNG) from the quasi-random Halton sequence (`halton`)
+//! and a scaled Householder reflection (`geometry`), producing an orthogonal
+//! integer basis whose `±` columns form the maximal positive basis
+//! `D_k = [H −H]`. Two parameters drive the mesh: a fine mesh size `Δᵐ` and a
+//! coarser poll size `Δᵖ`, linked through the integer mesh index `ℓ` by
+//! `Δᵖ = 2^{-ℓ}`, `Δᵐ = min{1, 4^{-ℓ}}` (OrthoMADS eq. (1)); `Δᵐ` shrinks faster
+//! than `Δᵖ`, so the number of available poll directions grows without bound.
+//! Because the directions are integer and trial points are `x_k + Δᵐ·d`, every
+//! poll point lies exactly on the mesh. The poll loop and bookkeeping live in
+//! the `driver` submodule.
+//!
+//! # State / solver split
+//!
+//! The incumbent and the poll size `Δᵖ` live on [`MadsState`](crate::MadsState);
+//! the mesh index, Halton-index schedule, and flat-scratch incumbent live on the
+//! solver (`Mads`'s `MadsWork`) — the same split the Powell-family DFO solvers
+//! use. So [`MadsState`](crate::MadsState) is generic over the parameter vector
+//! `V` only; the direction algebra is internal `Vec<f64>`/`Vec<i64>` scratch.
+//!
+//! # Termination
+//!
+//! MADS's natural convergence is the poll size `Δᵖ` reaching the configured floor
+//! `poll_size_min`; the solver signals it via
+//! [`TerminationReason::SolverConverged`]. Add [`MaxCostEvals`](crate::MaxCostEvals)
+//! to cap the evaluation budget, or [`MeshTolerance`](crate::MeshTolerance) to
+//! stop early at a coarser poll size.
+//!
+//! # Backends
+//!
+//! Backend-generic over the parameter vector: `Vec<f64>`, nalgebra, ndarray, and
+//! faer all work (the parameter type needs only [`Clone`], [`VectorLen`], and
+//! `Index`/`IndexMut`). The poll geometry is pure-Rust integer/`f64` scratch with
+//! no RNG, no `linalg`-tier ops, and no time — fully deterministic and wasm-clean.
+//!
+//! [`CostFunction`]: crate::core::problem::CostFunction
+//! [`VectorLen`]: crate::core::math::VectorLen
+//! [`TerminationReason::SolverConverged`]: crate::TerminationReason::SolverConverged
+
+pub(crate) mod driver;
+pub(crate) mod geometry;
+pub(crate) mod halton;
+pub(crate) mod progressive_barrier;
+
+use std::marker::PhantomData;
+
+use crate::core::constraint::{BoxConstraints, NonlinearInequalityConstraints};
+use crate::core::math::{Scalar, VectorLen};
+use crate::core::problem::{CostFunction, Problem};
+use crate::core::solver::Solver;
+use crate::core::state::{ConstrainedMadsState, MadsState};
+use crate::core::termination::TerminationReason;
+use crate::solver::nelder_mead::Unbounded;
+
+use driver::{MadsWork, Transition};
+use progressive_barrier::PbWork;
+
+/// Type-state marker: box-bound-constrained MADS (`Mads<Bounded>`), reached via
+/// [`Mads::bounded`]. Bounds are enforced by the **extreme barrier** — infeasible
+/// poll points are assigned `f = +∞` and rejected without evaluating the
+/// objective (Audet & Dennis 2006, §2). Pair with a problem implementing
+/// [`BoxConstraints`].
+pub struct Bounded;
+
+/// Type-state marker: nonlinearly-constrained MADS (`Mads<Constrained>`),
+/// reached via [`Mads::constrained`]. General nonlinear inequality constraints
+/// `c(x) ≤ 0` are handled by the **progressive barrier** (Audet & Dennis 2009):
+/// the solver tracks the aggregate violation `h(x) = Σⱼ max(cⱼ, 0)²` and walks a
+/// barrier threshold down to zero, so an **infeasible start is allowed**. Pair
+/// with a problem implementing [`NonlinearInequalityConstraints`].
+pub struct Constrained;
+
+/// MADS (Audet & Dennis 2006): mesh adaptive direct search, deterministic
+/// OrthoMADS instance — derivative-free local optimization for nonsmooth /
+/// non-continuous objectives.
+///
+/// Configure the poll-size schedule, then drive it with an
+/// [`Executor`](crate::Executor) over a [`MadsState`]:
+///
+/// ```
+/// use basin::{CostFunction, Executor, Mads, MadsState, MaxCostEvals};
+///
+/// // A nonsmooth objective (an L1 "valley") with minimizer (1, 2).
+/// struct AbsValley;
+/// impl CostFunction for AbsValley {
+///     type Param = Vec<f64>;
+///     type Output = f64;
+///     type Error = std::convert::Infallible;
+///     fn cost(&self, x: &Vec<f64>) -> Result<f64, std::convert::Infallible> {
+///         Ok((x[0] - 1.0).abs() + 2.0 * (x[1] - 2.0).abs())
+///     }
+/// }
+///
+/// let solver = Mads::new().with_initial_poll_size(1.0).with_min_poll_size(1e-9);
+/// let state = MadsState::new(vec![0.0, 0.0]);
+/// let result = Executor::new(AbsValley, solver, state)
+///     .terminate_on(MaxCostEvals(5_000))
+///     .run()
+///     .unwrap();
+/// assert!(result.best_cost() < 1e-6);
+/// ```
+///
+/// # Configuration
+///
+/// - [`with_initial_poll_size`](Self::with_initial_poll_size) — initial poll
+///   size `Δ₀` (a reasonable initial change to the variables; default `1.0`). It
+///   uniformly scales the mesh, so trial points stay on the scaled integer mesh.
+/// - [`with_min_poll_size`](Self::with_min_poll_size) — convergence floor on the
+///   poll size (default `1e-6`). The run converges once `Δᵖ` reaches it; must be
+///   `> 0` and `< Δ₀`.
+///
+/// # Constraints
+///
+/// Two opt-in constrained modes specialize the default unconstrained solver:
+///
+/// - [`bounded`](Self::bounded) → `Mads<Bounded>` handles box bounds by the
+///   **extreme barrier** (infeasible poll points get `f = +∞`); needs a problem
+///   implementing [`BoxConstraints`] and a feasible (or clamped) start.
+/// - [`constrained`](Self::constrained) → `Mads<Constrained>` handles general
+///   nonlinear inequality constraints `c(x) ≤ 0` by the **progressive barrier**
+///   (Audet & Dennis 2009): it tracks the aggregate violation
+///   `h(x) = Σⱼ max(cⱼ, 0)²` and drives a barrier threshold down to zero,
+///   exploring around both a feasible and an infeasible incumbent. Needs a
+///   problem implementing [`NonlinearInequalityConstraints`] and a
+///   [`ConstrainedMadsState`]; an **infeasible start is allowed**.
+///
+/// # Backends
+///
+/// Backend-generic over the parameter vector: `Vec<f64>`, nalgebra, ndarray, and
+/// faer all work. The poll geometry is internal pure-Rust integer/`f64` scratch,
+/// so the parameter type needs only [`Clone`], [`VectorLen`], and `Index`/`IndexMut`
+/// — never any `linalg`-tier op. Deterministic (no RNG) and wasm-clean.
+///
+/// # References
+///
+/// C. Audet & J. E. Dennis, Jr., *Mesh adaptive direct search algorithms for
+/// constrained optimization*, SIAM J. Optim. 17 (2006), pp. 188–217 (with the
+/// 2008 erratum). M. A. Abramson, C. Audet, J. E. Dennis, Jr. & S. Le Digabel,
+/// *OrthoMADS: A deterministic MADS instance with orthogonal directions*, SIAM
+/// J. Optim. 20 (2009), pp. 948–966. C. Audet & J. E. Dennis, Jr., *A
+/// progressive barrier for derivative-free nonlinear programming*, SIAM J.
+/// Optim. 20 (2009), pp. 445–472 (the constrained mode).
+pub struct Mads<Mode = Unbounded, F = f64> {
+    poll_size_init: F,
+    poll_size_min: F,
+    /// Built in [`Solver::init`]; the resumable poll loop + mesh schedule
+    /// (unconstrained / box-bounded modes).
+    work: Option<MadsWork<F>>,
+    /// Built in [`Solver::init`] for the constrained mode; the resumable
+    /// progressive-barrier poll loop. `None` in the other modes.
+    pb_work: Option<PbWork<F>>,
+    _mode: PhantomData<fn() -> Mode>,
+}
+
+impl<F: Scalar> Mads<Unbounded, F> {
+    /// A MADS solver with the default schedule (`Δ₀ = 1`, `poll_size_min =
+    /// 1e-6`). Tune with the `with_*` builders.
+    pub fn new() -> Self {
+        Self {
+            poll_size_init: F::from_f64(1.0).expect("1.0 representable"),
+            poll_size_min: F::from_f64(1e-6).expect("1e-6 representable"),
+            work: None,
+            pb_work: None,
+            _mode: PhantomData,
+        }
+    }
+}
+
+impl<Mode, F: Scalar> Mads<Mode, F> {
+    /// Set the initial poll size `Δ₀` — a reasonable initial change to the
+    /// variables. Uniformly scales the mesh.
+    pub fn with_initial_poll_size(mut self, poll_size_init: F) -> Self {
+        self.poll_size_init = poll_size_init;
+        self
+    }
+
+    /// Set the convergence floor on the poll size. Must satisfy `0 < floor < Δ₀`.
+    pub fn with_min_poll_size(mut self, poll_size_min: F) -> Self {
+        self.poll_size_min = poll_size_min;
+        self
+    }
+}
+
+impl<F: Scalar> Mads<Unbounded, F> {
+    /// Switch to the box-bound-constrained variant ([`Bounded`]). The resulting
+    /// `Mads<Bounded>` requires a problem implementing [`BoxConstraints`] and
+    /// enforces the bounds by the extreme barrier (infeasible poll points get
+    /// `f = +∞`).
+    /// An infeasible start is clamped into the box.
+    pub fn bounded(self) -> Mads<Bounded, F> {
+        Mads {
+            poll_size_init: self.poll_size_init,
+            poll_size_min: self.poll_size_min,
+            work: None,
+            pb_work: None,
+            _mode: PhantomData,
+        }
+    }
+
+    /// Switch to the nonlinearly-constrained variant ([`Constrained`]). The
+    /// resulting `Mads<Constrained>` requires a problem implementing
+    /// [`NonlinearInequalityConstraints`] (`c(x) ≤ 0`) and handles the
+    /// constraints by the **progressive barrier**, so an **infeasible start is
+    /// allowed**. Drive it with a [`ConstrainedMadsState`].
+    pub fn constrained(self) -> Mads<Constrained, F> {
+        Mads {
+            poll_size_init: self.poll_size_init,
+            poll_size_min: self.poll_size_min,
+            work: None,
+            pb_work: None,
+            _mode: PhantomData,
+        }
+    }
+}
+
+impl<F: Scalar> Default for Mads<Unbounded, F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Build a `V` from a flat `&[F]`, reusing `template` for type and length.
+fn fill_from<V, F>(template: &V, slice: &[F]) -> V
+where
+    V: Clone + std::ops::IndexMut<usize, Output = F>,
+    F: Copy,
+{
+    let mut v = template.clone();
+    for (i, &x) in slice.iter().enumerate() {
+        v[i] = x;
+    }
+    v
+}
+
+/// Copy a backend vector `V` into a flat `Vec<F>` of length `n`.
+fn to_vec<V, F>(v: &V, n: usize) -> Vec<F>
+where
+    V: std::ops::Index<usize, Output = F>,
+    F: Copy,
+{
+    (0..n).map(|i| v[i]).collect()
+}
+
+/// Whether any component of `x` lies outside `[lower, upper]`.
+fn out_of_box<F: Scalar>(x: &[F], lower: &[F], upper: &[F]) -> bool {
+    x.iter()
+        .zip(lower)
+        .zip(upper)
+        .any(|((&xi, &lo), &up)| xi < lo || xi > up)
+}
+
+impl<P, V, F> Solver<P, MadsState<V, F>> for Mads<Unbounded, F>
+where
+    F: Scalar,
+    P: CostFunction<Param = V, Output = F>,
+    V: Clone
+        + VectorLen
+        + std::ops::Index<usize, Output = F>
+        + std::ops::IndexMut<usize, Output = F>,
+{
+    type Error = P::Error;
+
+    fn init(
+        &mut self,
+        problem: &mut Problem<P>,
+        mut state: MadsState<V, F>,
+    ) -> Result<MadsState<V, F>, Self::Error> {
+        let n = state.param.vec_len();
+        assert!(n >= 1, "Mads requires a non-empty start point");
+
+        let x0: Vec<F> = (0..n).map(|i| state.param[i]).collect();
+        let template = state.param.clone();
+
+        let (work, best_x, best_f) = {
+            let mut eval =
+                |slice: &[F]| -> Result<F, P::Error> { problem.cost(&fill_from(&template, slice)) };
+            MadsWork::try_init(x0, self.poll_size_init, self.poll_size_min, &mut eval)?
+        };
+
+        state.param = fill_from(&template, &best_x);
+        state.cost = Some(best_f);
+        state.poll_size = work.poll_size();
+        state.mesh_index = work.mesh_index();
+        self.work = Some(work);
+        Ok(state)
+    }
+
+    fn next_iter(
+        &mut self,
+        problem: &mut Problem<P>,
+        mut state: MadsState<V, F>,
+    ) -> Result<(MadsState<V, F>, Option<TerminationReason>), Self::Error> {
+        let template = state.param.clone();
+        let work = self
+            .work
+            .as_mut()
+            .expect("Mads::init must run before next_iter");
+
+        let out = {
+            let mut eval =
+                |slice: &[F]| -> Result<F, P::Error> { problem.cost(&fill_from(&template, slice)) };
+            work.step(&mut eval)?
+        };
+        state.poll_size = work.poll_size();
+        state.mesh_index = work.mesh_index();
+
+        // Fold the step's improving evaluation into the running best (the
+        // reported iterate). MADS accepts only improving mesh points, so
+        // param/cost are monotone and coincide with best_param/best_cost.
+        let mut best_f = state.cost.expect("Mads::init seeds the cost");
+        for (xabs, f_new) in &out.evaluated {
+            if *f_new < best_f {
+                best_f = *f_new;
+                state.param = fill_from(&template, xabs);
+                state.cost = Some(best_f);
+            }
+        }
+
+        // The poll size reaching its floor is MADS's natural convergence.
+        let reason = match out.transition {
+            Transition::Converged => Some(TerminationReason::SolverConverged),
+            Transition::Continue => None,
+        };
+        Ok((state, reason))
+    }
+}
+
+/// Aggregate constraint violation `h(x) = Σⱼ max(cⱼ(x), 0)²` from the constraint
+/// vector `c(x)` (length `m`). `h = 0` exactly on the feasible set `c(x) ≤ 0`.
+fn violation<V, F>(c: &V, m: usize) -> F
+where
+    V: std::ops::Index<usize, Output = F>,
+    F: Scalar,
+{
+    let mut h = F::zero();
+    for j in 0..m {
+        let cj = c[j];
+        if cj > F::zero() {
+            h = h + cj * cj;
+        }
+    }
+    h
+}
+
+impl<P, V, F> Solver<P, ConstrainedMadsState<V, F>> for Mads<Constrained, F>
+where
+    F: Scalar,
+    P: CostFunction<Param = V, Output = F> + NonlinearInequalityConstraints,
+    V: Clone
+        + VectorLen
+        + std::ops::Index<usize, Output = F>
+        + std::ops::IndexMut<usize, Output = F>,
+{
+    type Error = P::Error;
+
+    fn init(
+        &mut self,
+        problem: &mut Problem<P>,
+        mut state: ConstrainedMadsState<V, F>,
+    ) -> Result<ConstrainedMadsState<V, F>, Self::Error> {
+        let n = state.param.vec_len();
+        assert!(n >= 1, "Mads requires a non-empty start point");
+
+        let m = problem.inner().num_constraints();
+        let x0: Vec<F> = (0..n).map(|i| state.param[i]).collect();
+        let template = state.param.clone();
+
+        let (work, best_x, best_f, best_h) = {
+            let mut eval = |slice: &[F]| -> Result<(F, F), P::Error> {
+                let xv = fill_from(&template, slice);
+                let f = problem.cost(&xv)?;
+                let c = problem.inner().constraints(&xv)?;
+                Ok((f, violation(&c, m)))
+            };
+            PbWork::try_init(x0, self.poll_size_init, self.poll_size_min, &mut eval)?
+        };
+
+        state.param = fill_from(&template, &best_x);
+        state.cost = Some(best_f);
+        state.constraint_violation = best_h;
+        state.poll_size = work.poll_size();
+        state.mesh_index = work.mesh_index();
+        self.pb_work = Some(work);
+        Ok(state)
+    }
+
+    fn next_iter(
+        &mut self,
+        problem: &mut Problem<P>,
+        mut state: ConstrainedMadsState<V, F>,
+    ) -> Result<(ConstrainedMadsState<V, F>, Option<TerminationReason>), Self::Error> {
+        let m = problem.inner().num_constraints();
+        let template = state.param.clone();
+        let work = self
+            .pb_work
+            .as_mut()
+            .expect("Mads::init must run before next_iter");
+
+        let out = {
+            let mut eval = |slice: &[F]| -> Result<(F, F), P::Error> {
+                let xv = fill_from(&template, slice);
+                let f = problem.cost(&xv)?;
+                let c = problem.inner().constraints(&xv)?;
+                Ok((f, violation(&c, m)))
+            };
+            work.step(&mut eval)?
+        };
+        state.poll_size = work.poll_size();
+        state.mesh_index = work.mesh_index();
+
+        // The progressive-barrier driver owns incumbent selection; adopt its
+        // reported incumbent (feasible if found, else best infeasible).
+        let (x_star, f_star, h_star) = out.incumbent;
+        state.param = fill_from(&template, &x_star);
+        state.cost = Some(f_star);
+        state.constraint_violation = h_star;
+
+        let reason = match out.transition {
+            Transition::Converged => Some(TerminationReason::SolverConverged),
+            Transition::Continue => None,
+        };
+        Ok((state, reason))
+    }
+}
+
+impl<P, V, F> Solver<P, MadsState<V, F>> for Mads<Bounded, F>
+where
+    F: Scalar,
+    P: CostFunction<Param = V, Output = F> + BoxConstraints,
+    V: Clone
+        + VectorLen
+        + std::ops::Index<usize, Output = F>
+        + std::ops::IndexMut<usize, Output = F>,
+{
+    type Error = P::Error;
+
+    fn init(
+        &mut self,
+        problem: &mut Problem<P>,
+        mut state: MadsState<V, F>,
+    ) -> Result<MadsState<V, F>, Self::Error> {
+        let n = state.param.vec_len();
+        assert!(n >= 1, "Mads requires a non-empty start point");
+
+        let lower = to_vec(problem.inner().lower(), n);
+        let upper = to_vec(problem.inner().upper(), n);
+        // Clamp an infeasible start into the box so the extreme barrier has a
+        // feasible incumbent to descend from.
+        let x0: Vec<F> = (0..n)
+            .map(|i| {
+                let xi = state.param[i];
+                if xi < lower[i] {
+                    lower[i]
+                } else if xi > upper[i] {
+                    upper[i]
+                } else {
+                    xi
+                }
+            })
+            .collect();
+        let template = state.param.clone();
+
+        let (work, best_x, best_f) = {
+            let mut eval = |slice: &[F]| -> Result<F, P::Error> {
+                if out_of_box(slice, &lower, &upper) {
+                    Ok(F::infinity()) // extreme barrier: reject without evaluating
+                } else {
+                    problem.cost(&fill_from(&template, slice))
+                }
+            };
+            MadsWork::try_init(x0, self.poll_size_init, self.poll_size_min, &mut eval)?
+        };
+
+        state.param = fill_from(&template, &best_x);
+        state.cost = Some(best_f);
+        state.poll_size = work.poll_size();
+        state.mesh_index = work.mesh_index();
+        self.work = Some(work);
+        Ok(state)
+    }
+
+    fn next_iter(
+        &mut self,
+        problem: &mut Problem<P>,
+        mut state: MadsState<V, F>,
+    ) -> Result<(MadsState<V, F>, Option<TerminationReason>), Self::Error> {
+        let n = state.param.vec_len();
+        let lower = to_vec(problem.inner().lower(), n);
+        let upper = to_vec(problem.inner().upper(), n);
+        let template = state.param.clone();
+        let work = self
+            .work
+            .as_mut()
+            .expect("Mads::init must run before next_iter");
+
+        let out = {
+            let mut eval = |slice: &[F]| -> Result<F, P::Error> {
+                if out_of_box(slice, &lower, &upper) {
+                    Ok(F::infinity())
+                } else {
+                    problem.cost(&fill_from(&template, slice))
+                }
+            };
+            work.step(&mut eval)?
+        };
+        state.poll_size = work.poll_size();
+        state.mesh_index = work.mesh_index();
+
+        let mut best_f = state.cost.expect("Mads::init seeds the cost");
+        for (xabs, f_new) in &out.evaluated {
+            if *f_new < best_f {
+                best_f = *f_new;
+                state.param = fill_from(&template, xabs);
+                state.cost = Some(best_f);
+            }
+        }
+
+        let reason = match out.transition {
+            Transition::Converged => Some(TerminationReason::SolverConverged),
+            Transition::Continue => None,
+        };
+        Ok((state, reason))
+    }
+}

--- a/crates/basin/src/solver/mads/driver.rs
+++ b/crates/basin/src/solver/mads/driver.rs
@@ -1,0 +1,151 @@
+//! OrthoMADS driver: the resumable poll loop and mesh/Halton bookkeeping.
+//!
+//! [`MadsWork`] holds the incumbent and the integer mesh index `ℓ`, and runs one
+//! OrthoMADS iteration per [`step`](MadsWork::step): generate the poll set
+//! `D_k = [H −H]` (from the Halton index `t_k` and `ℓ`), poll opportunistically,
+//! and update `ℓ` (success → `ℓ−1`, failure → `ℓ+1`). The incumbent is monotone
+//! non-increasing (only improving mesh points are accepted). All sizes scale by
+//! the configured initial poll size `Δ₀`, which keeps the trial points on the
+//! (scaled) integer mesh. See Abramson et al. 2009, Figure 2, and
+//! `references/orthomads-2009/NOTES.md`.
+
+use crate::core::math::Scalar;
+
+use super::geometry::{mesh_and_poll_size, poll_directions};
+use super::halton::halton_seed;
+
+/// What happened over one [`MadsWork::step`].
+pub(crate) enum Transition {
+    /// Keep going (a successful or unsuccessful iteration that has not yet
+    /// shrunk the poll size to the floor).
+    Continue,
+    /// The poll size reached the configured floor — MADS's natural convergence.
+    Converged,
+}
+
+/// The outcome of one step: the transition plus any improving evaluation (the
+/// new incumbent), for the solver to fold into best-tracking.
+pub(crate) struct StepOutcome<F> {
+    pub(crate) transition: Transition,
+    /// The accepted improving point (`(x, f(x))`) on a successful iteration,
+    /// empty on an unsuccessful one. Every polled point is still counted by the
+    /// `Problem` wrapper regardless.
+    pub(crate) evaluated: Vec<(Vec<F>, F)>,
+}
+
+/// Resumable OrthoMADS state carried on the [`Mads`](crate::solver::Mads) solver.
+pub(crate) struct MadsWork<F> {
+    n: usize,
+    /// Current incumbent (flat).
+    x: Vec<F>,
+    /// `f(x)`.
+    fx: F,
+    /// Mesh index `ℓ` (OrthoMADS eq. (1)).
+    ell: i32,
+    /// Halton seed `t₀ = p_n`.
+    t0: usize,
+    /// Largest `ℓ` reached so far — detects "poll size is the smallest so far".
+    ell_max: i32,
+    /// Largest Halton index used so far — feeds the non-smallest-poll branch.
+    t_max: usize,
+    /// Initial poll size `Δ₀` (uniform mesh scale); `Δᵖ = Δ₀·2^{-ℓ}`.
+    scale: F,
+    /// Convergence floor on the poll size.
+    poll_size_min: F,
+}
+
+impl<F: Scalar> MadsWork<F> {
+    /// Evaluate the starting point and build the initial state. Returns the work
+    /// plus the seeded incumbent `(x₀, f(x₀))`.
+    pub(crate) fn try_init<E>(
+        x0: Vec<F>,
+        poll_size_init: F,
+        poll_size_min: F,
+        eval: &mut dyn FnMut(&[F]) -> Result<F, E>,
+    ) -> Result<(Self, Vec<F>, F), E> {
+        let n = x0.len();
+        assert!(n >= 1, "Mads requires a non-empty start point");
+        let fx = eval(&x0)?;
+        let work = Self {
+            n,
+            x: x0.clone(),
+            fx,
+            ell: 0,
+            t0: halton_seed(n),
+            ell_max: 0,
+            t_max: 0,
+            scale: poll_size_init,
+            poll_size_min,
+        };
+        Ok((work, x0, fx))
+    }
+
+    /// The current poll size `Δᵖ = Δ₀·2^{-ℓ}`.
+    pub(crate) fn poll_size(&self) -> F {
+        let (_, poll) = mesh_and_poll_size(self.ell);
+        self.scale * F::from_f64(poll).expect("poll size representable")
+    }
+
+    /// The current mesh index `ℓ`.
+    pub(crate) fn mesh_index(&self) -> i32 {
+        self.ell
+    }
+
+    /// Run one OrthoMADS iteration: choose the Halton index, poll the
+    /// `2n`-direction set opportunistically, then update `ℓ`.
+    pub(crate) fn step<E>(
+        &mut self,
+        eval: &mut dyn FnMut(&[F]) -> Result<F, E>,
+    ) -> Result<StepOutcome<F>, E> {
+        // Halton index for this iteration (OrthoMADS Fig. 2): if the poll size is
+        // the smallest seen so far (ℓ at a new/tied max), tie it to ℓ; else take
+        // a fresh index past every one used before.
+        let t = if self.ell >= self.ell_max {
+            self.ell_max = self.ell;
+            (self.ell + self.t0 as i32) as usize // ℓ ≥ 0 in this branch
+        } else {
+            self.t_max + 1
+        };
+        self.t_max = self.t_max.max(t);
+
+        let (mesh_f64, _) = mesh_and_poll_size(self.ell);
+        let mesh = self.scale * F::from_f64(mesh_f64).expect("mesh size representable");
+        let dirs = poll_directions(t, self.ell, self.n);
+
+        // Opportunistic poll: move to the first improving mesh point.
+        let mut evaluated = Vec::new();
+        let mut improved = false;
+        for d in &dirs {
+            let mut trial = self.x.clone();
+            for i in 0..self.n {
+                let di = F::from_i64(d[i]).expect("integer direction representable");
+                trial[i] = trial[i] + mesh * di;
+            }
+            let f = eval(&trial)?;
+            if f < self.fx {
+                self.x = trial.clone();
+                self.fx = f;
+                evaluated.push((trial, f));
+                improved = true;
+                break;
+            }
+        }
+
+        // Mesh update: success coarsens (ℓ−1), failure refines (ℓ+1).
+        if improved {
+            self.ell -= 1;
+        } else {
+            self.ell += 1;
+        }
+
+        let transition = if self.poll_size() <= self.poll_size_min {
+            Transition::Converged
+        } else {
+            Transition::Continue
+        };
+        Ok(StepOutcome {
+            transition,
+            evaluated,
+        })
+    }
+}

--- a/crates/basin/src/solver/mads/geometry.rs
+++ b/crates/basin/src/solver/mads/geometry.rs
@@ -1,0 +1,207 @@
+//! OrthoMADS poll-direction geometry (Abramson, Audet, Dennis & Le Digabel
+//! 2009, §3.2–§3.4): the adjusted Halton direction `q_{t,ℓ}`, the
+//! scaled-Householder integer basis `H`, the maximal positive basis
+//! `D_k = [H −H]`, and the ℓ↔(Δᵐ, Δᵖ) mesh/poll sizes.
+//!
+//! All arithmetic is flat `f64` / `i64` and depends only on `(t, ℓ, n)` — it is
+//! backend- and scalar-`F`-independent. The direction outputs are exact integer
+//! vectors, so poll points `x_k + Δᵐ·d` land exactly on the mesh. Verified
+//! against the paper's Table 1/2 and Figure 1 (see the golden tests below and
+//! `references/orthomads-2009/NOTES.md`).
+
+use super::halton::halton_direction;
+
+/// Mesh size `Δᵐ = min{1, 4^{-ℓ}}` and poll size `Δᵖ = 2^{-ℓ}` for mesh index
+/// `ℓ` (OrthoMADS eq. (1), **signed ℓ**). Init `ℓ = 0 ⇒ Δᵐ = Δᵖ = 1`; an
+/// unsuccessful iteration does `ℓ ← ℓ+1` (refine), a success `ℓ ← ℓ−1`
+/// (coarsen). Powers of two, so exact in `f64`/`f32`.
+pub(crate) fn mesh_and_poll_size(ell: i32) -> (f64, f64) {
+    let poll = 2f64.powi(-ell); // Δᵖ = 2^{-ℓ}
+    let mesh = 4f64.powi(-ell).min(1.0); // Δᵐ = min{1, 4^{-ℓ}}
+    (mesh, poll)
+}
+
+/// The adjusted Halton direction `q_{t,ℓ} ∈ ℤⁿ` (OrthoMADS §3.2): scale and
+/// round the centered Halton direction `2u_t − e` to an integer vector whose
+/// norm is as close as possible to `2^{|ℓ|/2}` without exceeding it.
+///
+/// `q_t(α) = round(α (2u_t−e)/‖2u_t−e‖)` (round half away from zero). `‖q_t(α)‖`
+/// is a nondecreasing step function whose steps occur at the breakpoints
+/// `(2j+1)/(2|c_i|)`; `q_{t,ℓ}` is its value on the highest plateau with
+/// `‖q_t(α)‖ ≤ 2^{|ℓ|/2}` (problem (5), solved exactly via those breakpoints).
+pub(crate) fn adjusted_halton_direction(t: usize, ell: i32, n: usize) -> Vec<i64> {
+    let u = halton_direction(t, n);
+    // Centered direction w = 2u − e and its unit vector c = w/‖w‖.
+    let w: Vec<f64> = u.iter().map(|&ui| 2.0 * ui - 1.0).collect();
+    let w_norm = w.iter().map(|wi| wi * wi).sum::<f64>().sqrt();
+    // 2u_t − e = 0 only for n = t = 1, which the algorithm never uses (it seeds
+    // the Halton index at t₀ = p_n ≥ 2).
+    debug_assert!(w_norm > 0.0, "2u_t − e = 0 only for n = t = 1");
+    let c: Vec<f64> = w.iter().map(|wi| wi / w_norm).collect();
+
+    let target = 2f64.powf(f64::from(ell.unsigned_abs()) / 2.0); // 2^{|ℓ|/2}
+    let target_sq = target * target; // 2^{|ℓ|}, exact for the ℓ range we hit
+
+    let q_at =
+        |alpha: f64| -> Vec<i64> { c.iter().map(|ci| (alpha * ci).round() as i64).collect() };
+    let norm_sq = |q: &[i64]| -> i64 { q.iter().map(|qi| qi * qi).sum() };
+
+    // Beyond α where the largest single component alone exceeds the target,
+    // ‖q‖ > target for certain — bound the breakpoint enumeration there.
+    let c_max = c.iter().fold(0.0_f64, |m, ci| m.max(ci.abs()));
+    let alpha_ub = (target + 0.5) / c_max;
+
+    let mut breakpoints: Vec<f64> = Vec::new();
+    for ci in &c {
+        let aci = ci.abs();
+        if aci == 0.0 {
+            continue;
+        }
+        let mut j = 0u64;
+        loop {
+            let bp = (2 * j + 1) as f64 / (2.0 * aci);
+            if bp > alpha_ub {
+                break;
+            }
+            breakpoints.push(bp);
+            j += 1;
+        }
+    }
+    breakpoints.sort_by(|a, b| a.partial_cmp(b).expect("finite breakpoints"));
+
+    // Walk plateaus low → high. `q` is constant on `[b_k, b_{k+1})`; evaluate
+    // just past each breakpoint (a tiny nudge avoids fp round-at-the-step
+    // ambiguity). Keep the highest-norm `q` that is still feasible; stop at the
+    // first infeasible one (the norm is monotone).
+    let mut best = vec![0i64; n]; // plateau [0, b_1): q = 0
+    for &bp in &breakpoints {
+        let q = q_at(bp + bp * 1e-12);
+        if (norm_sq(&q) as f64) <= target_sq {
+            best = q;
+        } else {
+            break;
+        }
+    }
+    best
+}
+
+/// The scaled-Householder integer basis `H = ‖q‖²·Iₙ − 2·q·qᵀ` (OrthoMADS eq.
+/// (6)). Returns the `n` columns; each is an integer vector of norm `‖q‖²`, and
+/// the columns are mutually orthogonal.
+pub(crate) fn householder_basis(q: &[i64]) -> Vec<Vec<i64>> {
+    let n = q.len();
+    let q_norm_sq: i64 = q.iter().map(|qi| qi * qi).sum();
+    // Column j = H e_j = ‖q‖²·e_j − 2·q_j·q.
+    (0..n)
+        .map(|j| {
+            (0..n)
+                .map(|i| {
+                    let diag = if i == j { q_norm_sq } else { 0 };
+                    diag - 2 * q[j] * q[i]
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// The OrthoMADS poll set `D_k = [H −H]` (2n directions, the maximal positive
+/// basis) for Halton index `t`, mesh index `ℓ`, dimension `n` (OrthoMADS §3.4).
+pub(crate) fn poll_directions(t: usize, ell: i32, n: usize) -> Vec<Vec<i64>> {
+    let q = adjusted_halton_direction(t, ell, n);
+    let h = householder_basis(&q);
+    let mut dirs: Vec<Vec<i64>> = Vec::with_capacity(2 * n);
+    dirs.extend(h.iter().cloned());
+    dirs.extend(h.iter().map(|col| col.iter().map(|&x| -x).collect()));
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn norm_sq(q: &[i64]) -> i64 {
+        q.iter().map(|qi| qi * qi).sum()
+    }
+
+    fn dot(a: &[i64], b: &[i64]) -> i64 {
+        a.iter().zip(b).map(|(x, y)| x * y).sum()
+    }
+
+    #[test]
+    fn mesh_sizes_eq_1() {
+        assert_eq!(mesh_and_poll_size(0), (1.0, 1.0));
+        assert_eq!(mesh_and_poll_size(3), (1.0 / 64.0, 1.0 / 8.0)); // Figure 1
+        // After successes ℓ goes negative: mesh capped at 1, poll grows.
+        assert_eq!(mesh_and_poll_size(-2), (1.0, 4.0));
+    }
+
+    /// Table 2 of OrthoMADS (n = 4, eight pairs with t = ℓ + 7, t₀ = p_4 = 7):
+    /// exact adjusted Halton directions and their squared norms.
+    #[test]
+    fn adjusted_direction_table_2() {
+        let rows: [(usize, i32, [i64; 4], i64); 8] = [
+            (7, 0, [0, 0, 0, -1], 1),
+            (8, 1, [-1, 1, 0, 0], 2),
+            (9, 2, [0, -1, 1, -1], 3),
+            (10, 3, [-1, -1, -2, 0], 6),
+            (11, 4, [2, 2, -2, 1], 13),
+            (12, 5, [-3, -4, 0, 2], 29),
+            (13, 6, [3, 0, 3, 6], 54),
+            (14, 7, [-1, 5, 6, -8], 126),
+        ];
+        for (t, ell, q_expected, nsq_expected) in rows {
+            let q = adjusted_halton_direction(t, ell, 4);
+            assert_eq!(q, q_expected.to_vec(), "q_{{{t},{ell}}}");
+            assert_eq!(norm_sq(&q), nsq_expected, "‖q_{{{t},{ell}}}‖²");
+        }
+    }
+
+    /// Figure 1 of OrthoMADS, end to end: n = 2, (t, ℓ) = (6, 3).
+    #[test]
+    fn figure_1_full_chain() {
+        let q = adjusted_halton_direction(6, 3, 2);
+        assert_eq!(q, vec![-1, -2]);
+
+        let h = householder_basis(&q);
+        // H e_1 = (3, −4), H e_2 = (−4, −3).
+        assert_eq!(h[0], vec![3, -4]);
+        assert_eq!(h[1], vec![-4, -3]);
+
+        // Columns orthogonal, each of norm ‖q‖² = 5 (so squared norm 25 = ‖q‖⁴).
+        assert_eq!(dot(&h[0], &h[1]), 0);
+        assert_eq!(norm_sq(&h[0]), 25);
+        assert_eq!(norm_sq(&h[1]), 25);
+        assert_eq!((norm_sq(&h[0]) as f64).sqrt(), 5.0); // ‖H e_j‖ = ‖q‖²
+
+        // Poll set D_k = [H −H] has 2n = 4 directions.
+        let dirs = poll_directions(6, 3, 2);
+        assert_eq!(dirs.len(), 4);
+        assert_eq!(dirs[2], vec![-3, 4]);
+        assert_eq!(dirs[3], vec![4, 3]);
+
+        // Every d ∈ D_k satisfies Δᵐ‖d‖ = 5/64 < Δᵖ = 1/8 (caption).
+        let (mesh, poll) = mesh_and_poll_size(3);
+        for d in &dirs {
+            let dist = mesh * (norm_sq(d) as f64).sqrt();
+            assert!((dist - 5.0 / 64.0).abs() < 1e-12, "Δᵐ‖d‖ = {dist}");
+            assert!(dist < poll);
+        }
+    }
+
+    /// The columns of `[H −H]` are mutually orthogonal (any non-collinear pair),
+    /// so the cosine measure is the optimal `1/√n` (OrthoMADS eq. (2)).
+    #[test]
+    fn orthogonal_basis_in_higher_dim() {
+        let dirs = poll_directions(11, 4, 4);
+        assert_eq!(dirs.len(), 8);
+        let nsq = norm_sq(&dirs[0]);
+        for i in 0..4 {
+            assert_eq!(norm_sq(&dirs[i]), nsq, "equal column norms");
+            for j in 0..4 {
+                if i != j {
+                    assert_eq!(dot(&dirs[i], &dirs[j]), 0, "columns {i},{j} orthogonal");
+                }
+            }
+        }
+    }
+}

--- a/crates/basin/src/solver/mads/halton.rs
+++ b/crates/basin/src/solver/mads/halton.rs
@@ -1,0 +1,97 @@
+//! Deterministic Halton low-discrepancy sequence for OrthoMADS poll directions.
+//!
+//! OrthoMADS (Abramson, Audet, Dennis & Le Digabel 2009, §3.1) replaces LTMADS's
+//! random direction matrix with a deterministic construction seeded by the Halton
+//! sequence. This module provides the radical-inverse generator and the
+//! per-iteration Halton direction `u_t ∈ [0,1]^n`, plus the prime helper for the
+//! Halton seed `t₀ = p_n`. Every value is a pure function of `(t, n)` — no RNG,
+//! fully reproducible (see `references/orthomads-2009/NOTES.md`).
+
+/// The radical-inverse function `u_{t,p} = Σ_r a_{t,r,p} · p^{-(1+r)}`, where the
+/// `a_{t,r,p}` are the base-`p` digits of `t` (OrthoMADS §3.1).
+pub(crate) fn radical_inverse(t: usize, base: usize) -> f64 {
+    debug_assert!(base >= 2, "Halton base must be a prime ≥ 2");
+    let mut result = 0.0;
+    let mut f = 1.0 / base as f64;
+    let mut i = t;
+    while i > 0 {
+        result += f * (i % base) as f64;
+        i /= base;
+        f /= base as f64;
+    }
+    result
+}
+
+/// The `t`th Halton direction `u_t = (u_{t,p_1}, …, u_{t,p_n}) ∈ [0,1]^n`, using
+/// the first `n` primes as bases (OrthoMADS §3.1).
+pub(crate) fn halton_direction(t: usize, n: usize) -> Vec<f64> {
+    first_n_primes(n)
+        .into_iter()
+        .map(|p| radical_inverse(t, p))
+        .collect()
+}
+
+/// The first `n` prime numbers `p_1 = 2, p_2 = 3, p_3 = 5, …`.
+pub(crate) fn first_n_primes(n: usize) -> Vec<usize> {
+    let mut primes: Vec<usize> = Vec::with_capacity(n);
+    let mut candidate = 2;
+    while primes.len() < n {
+        if primes.iter().all(|&p| candidate % p != 0) {
+            primes.push(candidate);
+        }
+        candidate += 1;
+    }
+    primes
+}
+
+/// The Halton seed `t₀ = p_n`, the `n`th prime. OrthoMADS starts the sequence at
+/// `p_n` to remove the low-index correlation between dimensions (§3.1).
+pub(crate) fn halton_seed(n: usize) -> usize {
+    *first_n_primes(n)
+        .last()
+        .expect("n ≥ 1 for a non-empty problem")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f64, b: f64) {
+        assert!((a - b).abs() < 1e-12, "{a} != {b}");
+    }
+
+    #[test]
+    fn first_primes() {
+        assert_eq!(first_n_primes(4), vec![2, 3, 5, 7]);
+        assert_eq!(halton_seed(2), 3); // p_2 = 3 (used by Figure 1, n=2)
+        assert_eq!(halton_seed(4), 7); // p_4 = 7 (used by Table 2, n=4)
+    }
+
+    /// Table 1 of OrthoMADS (n = 4, t = 0..7): exact Halton directions.
+    #[test]
+    fn halton_table_1() {
+        // (t, [u_{t,2}, u_{t,3}, u_{t,5}, u_{t,7}]) read off Table 1.
+        let rows: [(usize, [f64; 4]); 8] = [
+            (0, [0.0, 0.0, 0.0, 0.0]),
+            (1, [1.0 / 2.0, 1.0 / 3.0, 1.0 / 5.0, 1.0 / 7.0]),
+            (2, [1.0 / 4.0, 2.0 / 3.0, 2.0 / 5.0, 2.0 / 7.0]),
+            (3, [3.0 / 4.0, 1.0 / 9.0, 3.0 / 5.0, 3.0 / 7.0]),
+            (4, [1.0 / 8.0, 4.0 / 9.0, 4.0 / 5.0, 4.0 / 7.0]),
+            (5, [5.0 / 8.0, 7.0 / 9.0, 1.0 / 25.0, 5.0 / 7.0]),
+            (6, [3.0 / 8.0, 2.0 / 9.0, 6.0 / 25.0, 6.0 / 7.0]),
+            (7, [7.0 / 8.0, 5.0 / 9.0, 11.0 / 25.0, 1.0 / 49.0]),
+        ];
+        for (t, expected) in rows {
+            let u = halton_direction(t, 4);
+            for (got, want) in u.iter().zip(expected.iter()) {
+                approx(*got, *want);
+            }
+        }
+    }
+
+    /// The footnote example: u_{5,3} = 1·3^-2 + 2·3^-1 = 7/9.
+    #[test]
+    fn radical_inverse_footnote() {
+        approx(radical_inverse(5, 3), 7.0 / 9.0);
+    }
+}

--- a/crates/basin/src/solver/mads/progressive_barrier.rs
+++ b/crates/basin/src/solver/mads/progressive_barrier.rs
@@ -1,0 +1,368 @@
+// Index-based loops mirror the OrthoMADS / PB exposition; the lint is allowed.
+#![allow(clippy::needless_range_loop)]
+
+//! Progressive-barrier driver for constrained MADS (Audet & Dennis 2009;
+//! Audet & Hare, *Derivative-Free and Blackbox Optimization*, 2nd ed., §10.5,
+//! Algorithm 10.2).
+//!
+//! Where the [extreme barrier](super::driver) rejects every infeasible point
+//! (`f = +∞`) and so needs a feasible start, the **progressive barrier** (PB)
+//! handles general nonlinear inequality constraints `c(x) ≤ 0` by tracking the
+//! aggregate constraint violation
+//!
+//! ```text
+//! h(x) = Σⱼ max(cⱼ(x), 0)²     (h = 0 ⇔ feasible)
+//! ```
+//!
+//! and exploring around **two** incumbents at once: the best **feasible** point
+//! `x_feas` (least `f`), and the best **infeasible** point `x_inf` (the
+//! nondominated infeasible point with `h ≤ h_max` and least `f`). The barrier
+//! threshold `h_max` starts at `+∞` (so an infeasible start is allowed) and is
+//! driven monotonically down to zero, abandoning ever-lower-violation infeasible
+//! incumbents until the iterates reach feasibility.
+//!
+//! Each [`step`](PbWork::step) polls the `2n`-direction OrthoMADS set
+//! `D_k = [H −H]` around both incumbents (reusing [`poll_directions`] and
+//! [`mesh_and_poll_size`] from [`geometry`](super::geometry)), then classifies
+//! the iteration and updates the mesh index `ℓ` and `h_max` per Figure 10.6:
+//!
+//! - **Dominating** — a trial dominates `x_feas` (`≺f`) or `x_inf` (`≺h`):
+//!   coarsen the mesh (`ℓ−1`), set `h_max ← h(x_inf)`. Opportunistic poll may
+//!   stop here.
+//! - **Improving** — non-dominating, but some visited infeasible point has
+//!   `0 < h < h(x_inf)`: keep the mesh, set
+//!   `h_max ← max{h(v) : h(v) < h(x_inf)}` (abandon the current `x_inf`).
+//! - **Unsuccessful** — neither: refine the mesh (`ℓ+1`), set
+//!   `h_max ← h(x_inf)`.
+//!
+//! The dominance / filter logic here is a fresh PB implementation, **not** a
+//! reuse of [`cobyla::filter`](crate::solver::cobyla) — COBYLA's
+//! `selectx`/`savefilt` encode a merit-`φ` selection over `cstrv = [maxⱼ cⱼ]₊`,
+//! whereas PB selects two incumbents over the `(h, f)` Pareto front with the
+//! squared-sum `h`. They are cross-referenced but share no code.
+//!
+//! [`poll_directions`]: super::geometry::poll_directions
+//! [`mesh_and_poll_size`]: super::geometry::mesh_and_poll_size
+
+use crate::core::math::Scalar;
+
+use super::driver::Transition;
+use super::geometry::{mesh_and_poll_size, poll_directions};
+use super::halton::halton_seed;
+
+/// The `(f, h)` oracle a [`PbWork`] step evaluates: it maps a flat point to its
+/// objective value `f` and aggregate constraint violation `h`.
+type PbEval<'a, F, E> = dyn FnMut(&[F]) -> Result<(F, F), E> + 'a;
+
+/// The outcome of one [`PbWork::step`]: the transition plus the reported
+/// incumbent `(x*, f*, h*)` — `x_feas` if a feasible point has been found, else
+/// the current `x_inf`.
+pub(crate) struct PbOutcome<F> {
+    pub(crate) transition: Transition,
+    pub(crate) incumbent: (Vec<F>, F, F),
+}
+
+/// Resumable progressive-barrier state carried on the
+/// [`Mads`](crate::solver::Mads) solver in the constrained mode.
+pub(crate) struct PbWork<F> {
+    n: usize,
+    /// Mesh index `ℓ` (OrthoMADS eq. (1)).
+    ell: i32,
+    /// Halton seed `t₀ = p_n`.
+    t0: usize,
+    /// Largest `ℓ` reached so far — detects "poll size is the smallest so far".
+    ell_max: i32,
+    /// Largest Halton index used so far.
+    t_max: usize,
+    /// Initial poll size `Δ₀` (uniform mesh scale); `Δᵖ = Δ₀·2^{-ℓ}`.
+    scale: F,
+    /// Convergence floor on the poll size.
+    poll_size_min: F,
+    /// Barrier threshold `h_max` (init `+∞`, nonincreasing toward `0`).
+    h_max: F,
+    /// Best feasible point found so far `(x, f)`, if any.
+    feasible: Option<(Vec<F>, F)>,
+    /// Every visited infeasible point `(x, f, h)` (`h > 0`). Needed in full: the
+    /// "improving" rule takes a max over all visited violations below `h(x_inf)`,
+    /// which can include dominated points.
+    infeasible: Vec<(Vec<F>, F, F)>,
+}
+
+impl<F: Scalar> PbWork<F> {
+    /// Evaluate the starting point and build the initial state. `eval` returns
+    /// `(f, h)` — the objective and the aggregate violation. Returns the work
+    /// plus the seeded incumbent `(x*, f*, h*)`.
+    pub(crate) fn try_init<E>(
+        x0: Vec<F>,
+        poll_size_init: F,
+        poll_size_min: F,
+        eval: &mut PbEval<F, E>,
+    ) -> Result<(Self, Vec<F>, F, F), E> {
+        let n = x0.len();
+        assert!(n >= 1, "Mads requires a non-empty start point");
+        let (f0, h0) = eval(&x0)?;
+        let mut work = Self {
+            n,
+            ell: 0,
+            t0: halton_seed(n),
+            ell_max: 0,
+            t_max: 0,
+            scale: poll_size_init,
+            poll_size_min,
+            h_max: F::infinity(),
+            feasible: None,
+            infeasible: Vec::new(),
+        };
+        work.record(x0, f0, h0);
+        let (xs, fs, hs) = work.reported_incumbent();
+        Ok((work, xs, fs, hs))
+    }
+
+    /// The current poll size `Δᵖ = Δ₀·2^{-ℓ}`.
+    pub(crate) fn poll_size(&self) -> F {
+        let (_, poll) = mesh_and_poll_size(self.ell);
+        self.scale * F::from_f64(poll).expect("poll size representable")
+    }
+
+    /// The current mesh index `ℓ`.
+    pub(crate) fn mesh_index(&self) -> i32 {
+        self.ell
+    }
+
+    /// File a visited point into the feasible incumbent or the infeasible list.
+    fn record(&mut self, x: Vec<F>, f: F, h: F) {
+        if h <= F::zero() {
+            // Feasible: keep only the least-f point (feasible dominance is f-only).
+            match &self.feasible {
+                Some((_, best)) if *best <= f => {}
+                _ => self.feasible = Some((x, f)),
+            }
+        } else {
+            self.infeasible.push((x, f, h));
+        }
+    }
+
+    /// Index into `infeasible` of `x_inf`: the point with `h ≤ h_max` and least
+    /// `f` (ties broken by least `h`), or `None` if no infeasible point lies
+    /// within the threshold.
+    fn select_x_inf(&self) -> Option<usize> {
+        let mut best: Option<usize> = None;
+        for (i, (_, f, h)) in self.infeasible.iter().enumerate() {
+            if *h > self.h_max {
+                continue;
+            }
+            match best {
+                Some(j) => {
+                    let (_, fj, hj) = &self.infeasible[j];
+                    if f < fj || (f == fj && h < hj) {
+                        best = Some(i);
+                    }
+                }
+                None => best = Some(i),
+            }
+        }
+        best
+    }
+
+    /// The point reported to the solver: `x_feas` if one exists, else `x_inf`.
+    /// At least one always exists (the start point was recorded).
+    fn reported_incumbent(&self) -> (Vec<F>, F, F) {
+        if let Some((x, f)) = &self.feasible {
+            (x.clone(), *f, F::zero())
+        } else {
+            let i = self
+                .select_x_inf()
+                .expect("a recorded point always yields an incumbent");
+            let (x, f, h) = &self.infeasible[i];
+            (x.clone(), *f, *h)
+        }
+    }
+
+    /// Run one PB iteration: poll the `2n` directions around both incumbents,
+    /// classify, then update `ℓ` and `h_max`.
+    pub(crate) fn step<E>(&mut self, eval: &mut PbEval<F, E>) -> Result<PbOutcome<F>, E> {
+        // 1. Incumbents at the start of the iteration.
+        let feas_pre = self.feasible.clone();
+        let inf_pre = self.select_x_inf().map(|i| self.infeasible[i].clone());
+        let h_inf_pre = inf_pre.as_ref().map(|t| t.2);
+
+        // 2. Halton index for this iteration (OrthoMADS Fig. 2).
+        let t = if self.ell >= self.ell_max {
+            self.ell_max = self.ell;
+            (self.ell + self.t0 as i32) as usize
+        } else {
+            self.t_max + 1
+        };
+        self.t_max = self.t_max.max(t);
+
+        let (mesh_f64, _) = mesh_and_poll_size(self.ell);
+        let mesh = self.scale * F::from_f64(mesh_f64).expect("mesh size representable");
+        let dirs = poll_directions(t, self.ell, self.n);
+
+        // Poll around both incumbents (those that exist). Opportunistic: stop on
+        // the first dominating trial.
+        let centers: Vec<Vec<F>> = [
+            feas_pre.as_ref().map(|(x, _)| x.clone()),
+            inf_pre.as_ref().map(|(x, _, _)| x.clone()),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        let mut dominating = false;
+        'poll: for center in &centers {
+            for d in &dirs {
+                let mut trial = center.clone();
+                for i in 0..self.n {
+                    let di = F::from_i64(d[i]).expect("integer direction representable");
+                    trial[i] = trial[i] + mesh * di;
+                }
+                let (f, h) = eval(&trial)?;
+                let feasible = h <= F::zero();
+                self.record(trial, f, h);
+
+                // Dominating? (vs the pre-iteration incumbents.)
+                if feasible {
+                    // y ≺f x_feas.
+                    if feas_pre.as_ref().is_none_or(|(_, ff)| f < *ff) {
+                        dominating = true;
+                        break 'poll;
+                    }
+                } else if let Some((_, fi, hi)) = &inf_pre {
+                    // y ≺h x_inf: f ≤ f_inf and h ≤ h_inf, at least one strict.
+                    if f <= *fi && h <= *hi && (f < *fi || h < *hi) {
+                        dominating = true;
+                        break 'poll;
+                    }
+                }
+            }
+        }
+
+        // 3. Classify and update ℓ and h_max (Algorithm 10.2 step 3).
+        if dominating {
+            self.ell -= 1;
+            if let Some(h) = h_inf_pre {
+                self.h_max = h;
+            }
+        } else if let Some(hp) = h_inf_pre {
+            // Improving iff some visited infeasible point has 0 < h < h(x_inf).
+            let below: Vec<F> = self
+                .infeasible
+                .iter()
+                .map(|(_, _, h)| *h)
+                .filter(|h| *h < hp)
+                .collect();
+            if below.is_empty() {
+                // Unsuccessful.
+                self.ell += 1;
+                self.h_max = hp;
+            } else {
+                // Improving: drop h_max just below the abandoned x_inf.
+                let new_h = below.into_iter().fold(F::neg_infinity(), F::max);
+                self.h_max = new_h;
+            }
+        } else {
+            // No infeasible incumbent (only feasible points so far) and no
+            // dominating feasible trial: an unsuccessful iteration.
+            self.ell += 1;
+        }
+
+        let incumbent = self.reported_incumbent();
+        let transition = if self.poll_size() <= self.poll_size_min {
+            Transition::Converged
+        } else {
+            Transition::Continue
+        };
+        Ok(PbOutcome {
+            transition,
+            incumbent,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+
+    /// `(f, h)` oracle over a flat point, for driving `PbWork` directly.
+    fn run_steps<O>(x0: Vec<f64>, mut oracle: O, steps: usize) -> PbWork<f64>
+    where
+        O: FnMut(&[f64]) -> (f64, f64),
+    {
+        let mut eval = |x: &[f64]| -> Result<(f64, f64), Infallible> { Ok(oracle(x)) };
+        let (mut work, _, _, _) =
+            PbWork::try_init(x0, 1.0, 1e-9, &mut eval).expect("init infallible");
+        for _ in 0..steps {
+            work.step(&mut eval).expect("step infallible");
+        }
+        work
+    }
+
+    /// h(x) = Σ max(cⱼ,0)² is exactly 0 on the feasible set and positive off it.
+    #[test]
+    fn record_routes_by_feasibility() {
+        let mut w: PbWork<f64> = PbWork {
+            n: 1,
+            ell: 0,
+            t0: 2,
+            ell_max: 0,
+            t_max: 0,
+            scale: 1.0,
+            poll_size_min: 1e-9,
+            h_max: f64::INFINITY,
+            feasible: None,
+            infeasible: Vec::new(),
+        };
+        w.record(vec![0.0], 1.0, 0.0); // feasible
+        w.record(vec![1.0], 0.5, 0.25); // infeasible
+        assert_eq!(w.feasible, Some((vec![0.0], 1.0)));
+        assert_eq!(w.infeasible.len(), 1);
+    }
+
+    /// x_inf is the least-f infeasible point within the h_max threshold.
+    #[test]
+    fn select_x_inf_picks_least_f_within_threshold() {
+        let mut w: PbWork<f64> = PbWork {
+            n: 1,
+            ell: 0,
+            t0: 2,
+            ell_max: 0,
+            t_max: 0,
+            scale: 1.0,
+            poll_size_min: 1e-9,
+            h_max: 2.0,
+            feasible: None,
+            infeasible: vec![
+                (vec![0.0], 5.0, 0.5),
+                (vec![1.0], 1.0, 1.5),
+                (vec![2.0], 0.0, 3.0), // h above threshold → excluded
+            ],
+        };
+        assert_eq!(w.select_x_inf(), Some(1));
+        w.h_max = 0.6; // now only the first qualifies
+        assert_eq!(w.select_x_inf(), Some(0));
+        w.h_max = 0.1; // none qualifies
+        assert_eq!(w.select_x_inf(), None);
+    }
+
+    /// A feasible objective: min f = x on x ≥ 0 (c = −x ≤ 0). The PB threshold
+    /// must walk down to 0 and the iterate reach feasibility near x = 0.
+    #[test]
+    fn drives_threshold_to_feasibility() {
+        // Start infeasible at x = −1 (h = 1). f = x.
+        let oracle = |x: &[f64]| {
+            let xi = x[0];
+            let c = -xi; // c ≤ 0 ⇔ x ≥ 0
+            let viol = c.max(0.0);
+            (xi, viol * viol)
+        };
+        let work = run_steps(vec![-1.0], oracle, 60);
+        // h_max has been driven down to (near) zero and a feasible incumbent
+        // with f ≈ 0 has been found.
+        assert!(work.h_max <= 1e-6, "h_max = {}", work.h_max);
+        let (_, f, h) = work.reported_incumbent();
+        assert!(h <= 1e-9, "reported violation {h}");
+        assert!(f.abs() < 1e-2, "reported f {f}");
+    }
+}

--- a/crates/basin/tests/mads_bounded.rs
+++ b/crates/basin/tests/mads_bounded.rs
@@ -1,0 +1,102 @@
+//! Integration tests for the box-constrained MADS variant
+//! (`Mads::new().bounded()`), which enforces bounds by the extreme barrier
+//! (infeasible poll points get `f = +∞`).
+//!
+//! Mirrors `bounded_nelder_mead.rs`: slack-bounds / tight-bounds / infeasible-
+//! start coverage on `BoothBoxed`. Backend coverage piggybacks on the
+//! unbounded `mads_public.rs` tests (the bounded path differs only in the
+//! barrier eval closure, which is backend-agnostic).
+
+use basin::problems::BoothBoxed;
+use basin::{Executor, Mads, MadsState, MaxCostEvals, State, TerminationReason};
+
+/// Slack bounds: the unconstrained Booth minimum `(1, 3)` lies inside `[-5, 5]²`,
+/// so the barrier never fires and MADS recovers the unconstrained optimum.
+#[test]
+fn slack_bounds_recover_unconstrained_minimum() {
+    let problem = BoothBoxed::<Vec<f64>>::new(vec![-5.0, -5.0], vec![5.0, 5.0]);
+
+    let result = Executor::new(
+        problem,
+        Mads::new()
+            .bounded()
+            .with_initial_poll_size(1.0)
+            .with_min_poll_size(1e-6),
+        MadsState::new(vec![0.0, 0.0]),
+    )
+    .max_iter(50_000)
+    .terminate_on(MaxCostEvals(20_000))
+    .run()
+    .unwrap();
+
+    assert!(result.best_cost() < 1e-6, "cost = {}", result.best_cost());
+    let x = result.best_param();
+    assert!(
+        (x[0] - 1.0).abs() < 1e-3,
+        "x[0] = {} (expected near 1)",
+        x[0]
+    );
+    assert!(
+        (x[1] - 3.0).abs() < 1e-3,
+        "x[1] = {} (expected near 3)",
+        x[1]
+    );
+}
+
+/// Tight bounds: the unconstrained minimum `(1, 3)` lies outside `[-1, 1]²`; the
+/// constrained optimum is the box corner `(1, 1)`. The extreme barrier rejects
+/// every poll point that steps out of the box, so MADS pins the incumbent to the
+/// active upper face and converges to the corner.
+#[test]
+fn tight_bounds_converge_to_box_corner() {
+    let problem = BoothBoxed::<Vec<f64>>::new(vec![-1.0, -1.0], vec![1.0, 1.0]);
+
+    let result = Executor::new(
+        problem,
+        Mads::new()
+            .bounded()
+            .with_initial_poll_size(1.0)
+            .with_min_poll_size(1e-8),
+        MadsState::new(vec![0.0, 0.0]),
+    )
+    .max_iter(50_000)
+    .terminate_on(MaxCostEvals(20_000))
+    .run()
+    .unwrap();
+
+    let x = result.best_param();
+    assert!(
+        (x[0] - 1.0).abs() < 1e-4,
+        "x[0] = {} (expected pinned at upper bound 1)",
+        x[0]
+    );
+    assert!(
+        (x[1] - 1.0).abs() < 1e-4,
+        "x[1] = {} (expected pinned at upper bound 1)",
+        x[1]
+    );
+}
+
+/// An infeasible start is clamped into the box at `init`, so with `max_iter = 0`
+/// the reported iterate is already feasible (the `(10, 10)` start clamps to the
+/// `(1, 1)` corner).
+#[test]
+fn infeasible_start_clamped_at_init() {
+    let problem = BoothBoxed::<Vec<f64>>::new(vec![-1.0, -1.0], vec![1.0, 1.0]);
+
+    let result = Executor::new(
+        problem,
+        Mads::new().bounded(),
+        MadsState::new(vec![10.0, 10.0]),
+    )
+    .max_iter(0)
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::MaxIter);
+    let x = result.state.param();
+    assert!(
+        (x[0] - 1.0).abs() < 1e-12 && (x[1] - 1.0).abs() < 1e-12,
+        "start (10, 10) should clamp to the corner (1, 1); got {x:?}"
+    );
+}

--- a/crates/basin/tests/mads_constrained.rs
+++ b/crates/basin/tests/mads_constrained.rs
@@ -1,0 +1,251 @@
+//! Public-API integration tests for the nonlinearly-constrained MADS variant
+//! (`Mads<Constrained>`, the progressive barrier).
+//!
+//! Exercises [`Mads::constrained`] through the framework — [`Executor`] over a
+//! [`ConstrainedMadsState`], with a problem carrying nonlinear inequality
+//! constraints via [`NonlinearInequalityConstraints`]. These confirm the public
+//! wiring: init/next_iter, the `c(x)` evaluation folded into the violation
+//! `h(x) = Σⱼ max(cⱼ, 0)²`, the V↔Vec bridge, count mirroring, feasibility of
+//! the returned point, and — the capability the extreme barrier lacks — that an
+//! **infeasible start** relaxes its way to a feasible optimum.
+//!
+//! The constraint trait is *function-valued* (no matrix carrier), so the
+//! backend-generic tests need only the parameter vector to be the backend type,
+//! guarding the support-matrix ✓ for nalgebra / ndarray / faer (same shape as
+//! `cobyla_public.rs`). MADS's poll geometry is deterministic and
+//! backend-independent, so every backend traces the identical run.
+
+use basin::{
+    ConstrainedMadsState, CostFunction, Executor, Mads, MaxCostEvals,
+    NonlinearInequalityConstraints, TerminationReason,
+};
+
+/// `min x0·x1` s.t. `x0² + x1² ≤ 1` on `Vec<f64>` (default features). The
+/// constrained optimum is `F* = −1/2` on the unit circle (at the 45° points).
+struct Disk;
+
+impl CostFunction for Disk {
+    type Param = Vec<f64>;
+    type Output = f64;
+    type Error = std::convert::Infallible;
+    fn cost(&self, x: &Vec<f64>) -> Result<f64, std::convert::Infallible> {
+        Ok(x[0] * x[1])
+    }
+}
+
+impl NonlinearInequalityConstraints for Disk {
+    fn constraints(&self, x: &Vec<f64>) -> Result<Vec<f64>, std::convert::Infallible> {
+        Ok(vec![x[0] * x[0] + x[1] * x[1] - 1.0])
+    }
+    fn num_constraints(&self) -> usize {
+        1
+    }
+}
+
+#[test]
+fn converges_to_disk_optimum() {
+    let result = Executor::new(
+        Disk,
+        Mads::new()
+            .with_initial_poll_size(1.0)
+            .with_min_poll_size(1e-7)
+            .constrained(),
+        ConstrainedMadsState::new(vec![0.0, 0.0]),
+    )
+    .terminate_on(MaxCostEvals(20_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        (result.best_cost() - (-0.5)).abs() < 1e-2,
+        "f = {}",
+        result.best_cost()
+    );
+    // The returned point is feasible and the reported violation is ~0.
+    let x = result.best_param();
+    assert!(x[0] * x[0] + x[1] * x[1] <= 1.0 + 1e-6, "infeasible {x:?}");
+    assert!(
+        result.state.constraint_violation() <= 1e-12,
+        "violation = {}",
+        result.state.constraint_violation()
+    );
+}
+
+/// The progressive barrier's defining capability: starting **outside** the
+/// feasible region, it relaxes its way to a feasible optimum (the extreme
+/// barrier would have nothing to descend from). Start far outside the disk.
+#[test]
+fn infeasible_start_reaches_feasible_optimum() {
+    let start = vec![2.0, -2.0]; // x0² + x1² = 8 > 1: strongly infeasible
+    let result = Executor::new(
+        Disk,
+        Mads::new()
+            .with_initial_poll_size(1.0)
+            .with_min_poll_size(1e-7)
+            .constrained(),
+        ConstrainedMadsState::new(start),
+    )
+    .terminate_on(MaxCostEvals(20_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    let x = result.best_param();
+    assert!(
+        x[0] * x[0] + x[1] * x[1] <= 1.0 + 1e-6,
+        "did not reach feasibility: {x:?}"
+    );
+    assert!(
+        (result.best_cost() - (-0.5)).abs() < 1e-2,
+        "f = {}",
+        result.best_cost()
+    );
+}
+
+/// The evaluation budget is honored: a tiny cap stops the run with
+/// [`TerminationReason::MaxCostEvals`].
+#[test]
+fn respects_eval_budget() {
+    let result = Executor::new(
+        Disk,
+        Mads::new().constrained(),
+        ConstrainedMadsState::new(vec![0.0, 0.0]),
+    )
+    .terminate_on(MaxCostEvals(50))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::MaxCostEvals);
+}
+
+/// Backend-generic: drive constrained MADS on nalgebra `DVector`. Guards the
+/// support-matrix ✓ for nalgebra (the param vector needs
+/// `VectorLen + Index + IndexMut`).
+#[cfg(feature = "nalgebra")]
+#[test]
+fn backend_generic_nalgebra() {
+    use nalgebra::DVector;
+
+    struct Disk;
+    impl CostFunction for Disk {
+        type Param = DVector<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &DVector<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok(x[0] * x[1])
+        }
+    }
+    impl NonlinearInequalityConstraints for Disk {
+        fn constraints(&self, x: &DVector<f64>) -> Result<DVector<f64>, std::convert::Infallible> {
+            Ok(DVector::from_vec(vec![x[0] * x[0] + x[1] * x[1] - 1.0]))
+        }
+        fn num_constraints(&self) -> usize {
+            1
+        }
+    }
+
+    let result = Executor::new(
+        Disk,
+        Mads::new().with_min_poll_size(1e-7).constrained(),
+        ConstrainedMadsState::new(DVector::from_vec(vec![0.0, 0.0])),
+    )
+    .terminate_on(MaxCostEvals(20_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        (result.best_cost() - (-0.5)).abs() < 1e-2,
+        "f = {}",
+        result.best_cost()
+    );
+    let x = result.best_param();
+    assert!(x[0] * x[0] + x[1] * x[1] <= 1.0 + 1e-6, "infeasible {x:?}");
+}
+
+/// Backend-generic: drive constrained MADS on ndarray `Array1`.
+#[cfg(feature = "ndarray")]
+#[test]
+fn backend_generic_ndarray() {
+    use ndarray::Array1;
+
+    struct Disk;
+    impl CostFunction for Disk {
+        type Param = Array1<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &Array1<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok(x[0] * x[1])
+        }
+    }
+    impl NonlinearInequalityConstraints for Disk {
+        fn constraints(&self, x: &Array1<f64>) -> Result<Array1<f64>, std::convert::Infallible> {
+            Ok(Array1::from_vec(vec![x[0] * x[0] + x[1] * x[1] - 1.0]))
+        }
+        fn num_constraints(&self) -> usize {
+            1
+        }
+    }
+
+    let result = Executor::new(
+        Disk,
+        Mads::new().with_min_poll_size(1e-7).constrained(),
+        ConstrainedMadsState::new(Array1::from_vec(vec![0.0, 0.0])),
+    )
+    .terminate_on(MaxCostEvals(20_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        (result.best_cost() - (-0.5)).abs() < 1e-2,
+        "f = {}",
+        result.best_cost()
+    );
+    let x = result.best_param();
+    assert!(x[0] * x[0] + x[1] * x[1] <= 1.0 + 1e-6, "infeasible {x:?}");
+}
+
+/// Backend-generic: drive constrained MADS on faer `Col`.
+#[cfg(feature = "faer")]
+#[test]
+fn backend_generic_faer() {
+    use faer::Col;
+
+    struct Disk;
+    impl CostFunction for Disk {
+        type Param = Col<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &Col<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok(x[0] * x[1])
+        }
+    }
+    impl NonlinearInequalityConstraints for Disk {
+        fn constraints(&self, x: &Col<f64>) -> Result<Col<f64>, std::convert::Infallible> {
+            Ok(Col::from_fn(1, |_| x[0] * x[0] + x[1] * x[1] - 1.0))
+        }
+        fn num_constraints(&self) -> usize {
+            1
+        }
+    }
+
+    let result = Executor::new(
+        Disk,
+        Mads::new().with_min_poll_size(1e-7).constrained(),
+        ConstrainedMadsState::new(Col::from_fn(2, |_| 0.0)),
+    )
+    .terminate_on(MaxCostEvals(20_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        (result.best_cost() - (-0.5)).abs() < 1e-2,
+        "f = {}",
+        result.best_cost()
+    );
+    let x = result.best_param();
+    assert!(x[0] * x[0] + x[1] * x[1] <= 1.0 + 1e-6, "infeasible {x:?}");
+}

--- a/crates/basin/tests/mads_public.rs
+++ b/crates/basin/tests/mads_public.rs
@@ -1,0 +1,288 @@
+//! Public-API integration tests for the MADS (OrthoMADS) solver.
+//!
+//! Exercises [`Mads`] through the framework — [`Executor`] over a [`MadsState`],
+//! with framework termination ([`MaxCostEvals`], [`MeshTolerance`]). The
+//! direction machinery is validated against the OrthoMADS paper by the in-crate
+//! `solver::mads` golden tests; these confirm the public wiring (init/next_iter,
+//! the V↔Vec bridge, count mirroring, convergence / budget / early-stop paths)
+//! and convergence on smooth problems across backends.
+
+use basin::{
+    CostFunction, Executor, Mads, MadsState, MaxCostEvals, MeshTolerance, TerminationReason,
+};
+
+/// Chained Rosenbrock (basin coefficient form), minimum 0 at the all-ones point.
+struct Rosenbrock;
+
+impl CostFunction for Rosenbrock {
+    type Param = Vec<f64>;
+    type Output = f64;
+    type Error = std::convert::Infallible;
+    fn cost(&self, x: &Vec<f64>) -> Result<f64, std::convert::Infallible> {
+        Ok((0..x.len() - 1)
+            .map(|i| (1.0 - x[i]).powi(2) + 100.0 * (x[i + 1] - x[i] * x[i]).powi(2))
+            .sum())
+    }
+}
+
+/// Sphere, minimum 0 at the origin.
+struct Sphere;
+
+impl CostFunction for Sphere {
+    type Param = Vec<f64>;
+    type Output = f64;
+    type Error = std::convert::Infallible;
+    fn cost(&self, x: &Vec<f64>) -> Result<f64, std::convert::Infallible> {
+        Ok(x.iter().map(|xi| xi * xi).sum())
+    }
+}
+
+#[test]
+fn converges_on_sphere() {
+    let result = Executor::new(
+        Sphere,
+        Mads::new()
+            .with_initial_poll_size(1.0)
+            .with_min_poll_size(1e-8),
+        MadsState::new(vec![2.0, -3.0, 1.5]),
+    )
+    .terminate_on(MaxCostEvals(10_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        result.best_cost() < 1e-10,
+        "best_cost = {}",
+        result.best_cost()
+    );
+    // The reported iterate is the best (monotone), so the two coincide.
+    assert_eq!(result.cost(), result.best_cost());
+}
+
+#[test]
+fn converges_on_rosenbrock_2d() {
+    let result = Executor::new(
+        Rosenbrock,
+        Mads::new()
+            .with_initial_poll_size(0.5)
+            .with_min_poll_size(1e-7),
+        MadsState::new(vec![-1.2, 1.0]),
+    )
+    // MADS is a poll-only direct search, so it needs many iterations on the
+    // Rosenbrock valley; let convergence / the eval budget govern, not max_iter.
+    .max_iter(100_000)
+    .terminate_on(MaxCostEvals(20_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        result.best_cost() < 1e-4,
+        "best_cost = {}",
+        result.best_cost()
+    );
+    let x = result.best_param();
+    assert!(
+        (x[0] - 1.0).abs() < 1e-2 && (x[1] - 1.0).abs() < 1e-2,
+        "x = {x:?}"
+    );
+}
+
+#[test]
+fn mesh_tolerance_stops_early() {
+    let result = Executor::new(
+        Rosenbrock,
+        // Configured to drive the poll size to 1e-12, but MeshTolerance cuts it
+        // off at a coarse poll size first.
+        Mads::new()
+            .with_initial_poll_size(0.5)
+            .with_min_poll_size(1e-12),
+        MadsState::new(vec![-1.2, 1.0]),
+    )
+    .terminate_on(MeshTolerance::new(1e-3))
+    .terminate_on(MaxCostEvals(50_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::MeshTolerance);
+    assert!(
+        result.state.poll_size() <= 1e-3,
+        "poll_size = {}",
+        result.state.poll_size()
+    );
+}
+
+#[test]
+fn respects_cost_eval_budget() {
+    let result = Executor::new(
+        Rosenbrock,
+        Mads::new()
+            .with_initial_poll_size(0.5)
+            .with_min_poll_size(1e-12),
+        MadsState::new(vec![-1.2, 1.0]),
+    )
+    .terminate_on(MaxCostEvals(50))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::MaxCostEvals);
+    assert!(
+        result.cost_evals() >= 50,
+        "cost_evals = {}",
+        result.cost_evals()
+    );
+}
+
+/// The motivating case: on a **discontinuous** objective, MADS converges where
+/// the Nelder-Mead simplex stalls. On the Step staircase, NM's initial simplex
+/// (5% offsets) lands entirely within one plateau — all vertices tie, so the
+/// simplex degenerates and never escapes the start cell. MADS steps down the
+/// staircase on its mesh and reaches the minimum. Both run from the same start
+/// with the same budget.
+#[test]
+fn outperforms_nelder_mead_on_discontinuous_step() {
+    use basin::problems::Step;
+    use basin::{BasicSimplexState, NelderMead, SimplexTolerance};
+
+    let start = vec![4.2, -3.2];
+    let budget = 5_000;
+
+    let mads = Executor::new(
+        Step::<Vec<f64>>::default(),
+        Mads::new()
+            .with_initial_poll_size(1.0)
+            .with_min_poll_size(1e-6),
+        MadsState::new(start.clone()),
+    )
+    .max_iter(100_000)
+    .terminate_on(MaxCostEvals(budget))
+    .run()
+    .unwrap();
+
+    let nm = Executor::new(
+        Step::<Vec<f64>>::default(),
+        NelderMead::new(),
+        BasicSimplexState::new(start.clone()),
+    )
+    .max_iter(100_000)
+    .terminate_on(MaxCostEvals(budget))
+    .terminate_on(SimplexTolerance::new(1e-12, 1e-12))
+    .run()
+    .unwrap();
+
+    // MADS reaches the global-minimum plateau (value 0).
+    assert_eq!(
+        mads.best_cost(),
+        0.0,
+        "MADS best_cost = {}",
+        mads.best_cost()
+    );
+    // Nelder-Mead degenerates on the start plateau and stalls above it.
+    assert!(
+        nm.best_cost() > mads.best_cost(),
+        "NM {} should stall above MADS {}",
+        nm.best_cost(),
+        mads.best_cost()
+    );
+}
+
+/// Backend-generic over the parameter vector: drive MADS on `nalgebra`'s
+/// `DVector` to prove the `V`-generic solver/state work outside `Vec<f64>`.
+#[cfg(feature = "nalgebra")]
+#[test]
+fn backend_generic_nalgebra() {
+    use nalgebra::DVector;
+
+    struct SphereN;
+    impl CostFunction for SphereN {
+        type Param = DVector<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &DVector<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok(x.iter().map(|xi| xi * xi).sum())
+        }
+    }
+
+    let result = Executor::new(
+        SphereN,
+        Mads::new().with_min_poll_size(1e-8),
+        MadsState::new(DVector::from_vec(vec![2.0, -3.0, 1.5])),
+    )
+    .terminate_on(MaxCostEvals(10_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        result.best_cost() < 1e-10,
+        "best_cost = {}",
+        result.best_cost()
+    );
+}
+
+/// Backend-generic over `ndarray`'s `Array1`.
+#[cfg(feature = "ndarray")]
+#[test]
+fn backend_generic_ndarray() {
+    use ndarray::Array1;
+
+    struct SphereA;
+    impl CostFunction for SphereA {
+        type Param = Array1<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &Array1<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok(x.iter().map(|xi| xi * xi).sum())
+        }
+    }
+
+    let result = Executor::new(
+        SphereA,
+        Mads::new().with_min_poll_size(1e-8),
+        MadsState::new(Array1::from_vec(vec![2.0, -3.0, 1.5])),
+    )
+    .terminate_on(MaxCostEvals(10_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        result.best_cost() < 1e-10,
+        "best_cost = {}",
+        result.best_cost()
+    );
+}
+
+/// Backend-generic over `faer`'s `Col` vector.
+#[cfg(feature = "faer")]
+#[test]
+fn backend_generic_faer() {
+    use faer::Col;
+
+    struct SphereF;
+    impl CostFunction for SphereF {
+        type Param = Col<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &Col<f64>) -> Result<f64, std::convert::Infallible> {
+            Ok((0..x.nrows()).map(|i| x[i] * x[i]).sum())
+        }
+    }
+
+    let result = Executor::new(
+        SphereF,
+        Mads::new().with_min_poll_size(1e-8),
+        MadsState::new(Col::<f64>::from_fn(3, |i| [2.0, -3.0, 1.5][i])),
+    )
+    .terminate_on(MaxCostEvals(10_000))
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!(
+        result.best_cost() < 1e-10,
+        "best_cost = {}",
+        result.best_cost()
+    );
+}

--- a/web/src/lib/solvers.ts
+++ b/web/src/lib/solvers.ts
@@ -114,6 +114,12 @@ export const SOLVERS: SolverMeta[] = [
         options: [],
     },
     {
+        kind: SolverKind.Mads,
+        label: 'MADS (mesh adaptive direct search)',
+        blurb: 'Deterministic OrthoMADS poll on a shrinking mesh; converges on nonsmooth objectives.',
+        options: [],
+    },
+    {
         kind: SolverKind.Lbfgs,
         label: 'L-BFGS (limited-memory quasi-Newton)',
         blurb: 'Two-loop recursion with a Moré–Thuente line search.',

--- a/web/src/routes/docs/solvers/+page.svx
+++ b/web/src/routes/docs/solvers/+page.svx
@@ -32,6 +32,17 @@ trailing note cites the paper it implements (or the source it ports).
   `CostFunction`. Implements Lagarias et al. (1998); `NelderMead::adaptive()`
   uses the dimension-aware coefficients of Gao & Han (2012), and the projected
   variant follows Luersen & Le Riche (2004).
+- **[`Mads`](https://docs.rs/basin/latest/basin/solver/mads/struct.Mads.html)**
+  — mesh adaptive direct search (the deterministic OrthoMADS instance): polls a
+  positive spanning set of `2n` directions on a shrinking mesh, generated from
+  the Halton sequence and a scaled Householder reflection. Unlike Nelder-Mead it
+  has a convergence guarantee on nonsmooth / non-continuous objectives, a
+  box-constrained variant (`Mads::bounded()`) via the extreme barrier, and a
+  nonlinearly-constrained variant (`Mads::constrained()`) handling `c(x) ≤ 0`
+  via the progressive barrier (which tolerates an infeasible start). Needs only
+  a `CostFunction` (plus `NonlinearInequalityConstraints` for the constrained
+  mode). Implements Audet & Dennis (2006), OrthoMADS (Abramson, Audet, Dennis &
+  Le Digabel 2009), and the progressive barrier (Audet & Dennis 2009).
 - **[`Newuoa`](https://docs.rs/basin/latest/basin/solver/newuoa/struct.Newuoa.html)**
   — Powell's model-based trust-region method: maintains a quadratic surrogate
   interpolating the objective on `2n+1` points and updates it by the
@@ -171,6 +182,7 @@ parameter type, ✗ means it is a compile-time error (the tiering rule above).
 | `Sgd` | First-order | ✓ | ✓ | ✓ | ✓ |
 | `ProjectedGradientDescent` | First-order | ✓ | ✓ | ✓ | ✓ |
 | `NelderMead` | Derivative-free | ✓ | ✓ | ✓ | ✓ |
+| `Mads` | Derivative-free | ✓ | ✓ | ✓ | ✓ |
 | `Newuoa` | Derivative-free | ✓ | ✓ | ✓ | ✓ |
 | `Bobyqa` | Derivative-free | ✓ | ✓ | ✓ | ✓ |
 | `Lincoa` | Derivative-free | ✓ | ✓ | ✓ | ✓ |


### PR DESCRIPTION
Mesh adaptive direct search for nonsmooth / non-continuous objectives, the deterministic OrthoMADS instance (Halton + scaled Householder, no RNG). Unbounded and box-constrained (extreme barrier via `.bounded()`) variants; vector-tier only, so backend-generic across all four backends and wasm-clean.

- solver/mads + solver/mads/{halton,geometry,driver}: OrthoMADS poll geometry and the resumable driver. Golden-tested against the paper's Table 1/2 and Figure 1 (exact Halton, adjusted-direction and Householder values).
- core/state/mads (MadsState) + MeshState trait + MeshTolerance criterion (TerminationReason::MeshTolerance); SolverConverged at the poll-size floor. Structured like the Powell DFO solvers (flat-internal arithmetic, MadsWork driver, V<->Vec bridge), without reusing the quadratic core.
- problems/step: De Jong discontinuous staircase, used to demonstrate MADS reaching the minimum where Nelder-Mead degenerates on a plateau.
- public surface + web catalogue (basin-wasm SolverKind::Mads, solvers.ts, docs catalogue + backend matrix).

Anchored to Audet & Dennis (2006), the 2008 erratum, and OrthoMADS (Abramson, Audet, Dennis & Le Digabel 2009). Progressive-barrier nonlinear constraints and a CMA-ES search step are deferred to follow-ups.