### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "fc5b065ce37fd6e84b32b190d4258fd45bdf4344",
+  "baseline-sha": "ea1164bf52f458f230d268d39be28d31ea7134d0",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.1.0",
-      "tag": "v1.1.0"
+      "version": "1.2.0",
+      "tag": "v1.2.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.1.0",
-      "tag": "v1.1.0"
+      "version": "1.2.0",
+      "tag": "v1.2.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.2.0](https://github.com/jolars/basin/compare/v1.1.0...v1.2.0) (2026-06-22)
+
+### Features
+- **executor:** add from_start convenience constructor ([`ea1164b`](https://github.com/jolars/basin/commit/ea1164bf52f458f230d268d39be28d31ea7134d0))
+- **solver:** add trust-region Newton solver ([`7cbd2d4`](https://github.com/jolars/basin/commit/7cbd2d46f70164f4ce16794223c905a40d53794b))
+- **backends:** add nalgebra-lapack feature for LAPACK-backed factorizations ([`1742321`](https://github.com/jolars/basin/commit/1742321469ab8e75beadb3951ac4b9131892e7dd))
+- **bench:** add basin-vs-nlopt NEWUOA convergence comparison ([`1e2eb46`](https://github.com/jolars/basin/commit/1e2eb465ca776d28f30912fe6fe6fdcd9711f060))
+
 ## [1.1.0](https://github.com/jolars/basin/compare/v1.0.0...v1.1.0) (2026-06-21)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "criterion",
  "faer",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "competitor-bench"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM / GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [1.2.0](https://github.com/jolars/basin/compare/v1.1.0...v1.2.0) (2026-06-22)

### Features
- **executor:** add from_start convenience constructor ([`ea1164b`](https://github.com/jolars/basin/commit/ea1164bf52f458f230d268d39be28d31ea7134d0))
- **solver:** add trust-region Newton solver ([`7cbd2d4`](https://github.com/jolars/basin/commit/7cbd2d46f70164f4ce16794223c905a40d53794b))
- **backends:** add nalgebra-lapack feature for LAPACK-backed factorizations ([`1742321`](https://github.com/jolars/basin/commit/1742321469ab8e75beadb3951ac4b9131892e7dd))
- **bench:** add basin-vs-nlopt NEWUOA convergence comparison ([`1e2eb46`](https://github.com/jolars/basin/commit/1e2eb465ca776d28f30912fe6fe6fdcd9711f060))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).