### PR TITLE
feat(solver): add trust-region Newton solver

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -129,6 +129,32 @@ the previous lands.
       `docs/newuoa-roadmap.md`.** Paper-anchored --- implement from the papers,
       cross-check against PRIMA.
 
+- [ ] **General trust-region Newton solver (the `Hessian`-trait consumer).** A
+      general unconstrained minimizer consuming the `Hessian` trait --- the
+      second-order solver that trait + `FiniteDiff` were added ahead of. Modeled
+      on argmin's `trustregion` structure (outer loop + pluggable subproblem),
+      anchored to Nocedal & Wright Ch. 4 (Algorithm 4.1) and the in-repo TRSAPP
+      truncated-CG (NEWUOA), **not** a port. (gomez's TrustRegion was rejected as
+      a model: it's a nonlinear-systems `f(x)=0` root-finder, overlapping
+      LM/`Trf`, not a general minimizer.) Trust radius δ + cached g/B live in the
+      solver struct (LM's `mu`/`nu` precedent), not on state; rejected steps
+      re-solve with smaller δ at zero extra gradient/Hessian evals. New general
+      `(g, B)` subproblem seam, distinct from the Powell `QuadraticModel`
+      `TrustRegionSubproblem` seam (different model type). **v1 subproblems:**
+      Steihaug-CG (matrix-free, `MatVec` only --- all backends, wasm-clean; the
+      default), Dogleg (Cholesky Newton step via `LinearSolveSpd` + SPD fallback
+      --- all backends but ndarray), Cauchy point (closed-form baseline,
+      universal). v1 forms full B once per accepted iterate (Dogleg needs it
+      anyway); a matrix-free `HessianProduct` trait so Steihaug needn't form B is
+      a future additive extension.
+  - **Deferred: Moré-Sorensen exact subproblem step.** The near-exact global
+        solve (secular equation, hard case) via `SymmetricEigen` + Cholesky is
+        out of v1 scope. It would require ingesting Moré & Sorensen (1983),
+        "Computing a Trust Region Step" (paper-anchored, per the no-invention
+        tenet). Add it as a fourth subproblem strategy once a consumer wants the
+        extra robustness; until then v1's three iterative/closed-form strategies
+        cover the common cases.
+
 ## Cleanup / design debt (review notes)
 
 Surfaced while implementing the termination layer. Not blocking, but each gets

--- a/TODO.md
+++ b/TODO.md
@@ -129,24 +129,31 @@ the previous lands.
       `docs/newuoa-roadmap.md`.** Paper-anchored --- implement from the papers,
       cross-check against PRIMA.
 
-- [ ] **General trust-region Newton solver (the `Hessian`-trait consumer).** A
-      general unconstrained minimizer consuming the `Hessian` trait --- the
-      second-order solver that trait + `FiniteDiff` were added ahead of. Modeled
-      on argmin's `trustregion` structure (outer loop + pluggable subproblem),
-      anchored to Nocedal & Wright Ch. 4 (Algorithm 4.1) and the in-repo TRSAPP
-      truncated-CG (NEWUOA), **not** a port. (gomez's TrustRegion was rejected as
-      a model: it's a nonlinear-systems `f(x)=0` root-finder, overlapping
-      LM/`Trf`, not a general minimizer.) Trust radius δ + cached g/B live in the
-      solver struct (LM's `mu`/`nu` precedent), not on state; rejected steps
-      re-solve with smaller δ at zero extra gradient/Hessian evals. New general
-      `(g, B)` subproblem seam, distinct from the Powell `QuadraticModel`
-      `TrustRegionSubproblem` seam (different model type). **v1 subproblems:**
-      Steihaug-CG (matrix-free, `MatVec` only --- all backends, wasm-clean; the
-      default), Dogleg (Cholesky Newton step via `LinearSolveSpd` + SPD fallback
-      --- all backends but ndarray), Cauchy point (closed-form baseline,
+- [x] **General trust-region Newton solver (the `Hessian`-trait consumer).**
+      BUILT (branch `trust-region`): public `TrustRegion<Sub, F>` over
+      `BasicState`, consuming the `Hessian` trait --- the second-order solver
+      that trait + `FiniteDiff` were added ahead of. Modeled on argmin's
+      `trustregion` structure (outer loop + pluggable subproblem), anchored to
+      Nocedal & Wright Ch. 4 (Algorithm 4.1) and the in-repo TRSAPP truncated-CG
+      (NEWUOA), **not** a port. (gomez's TrustRegion was rejected as a model:
+      it's a nonlinear-systems `f(x)=0` root-finder, overlapping LM/`Trf`, not a
+      general minimizer.) Trust radius δ lives in the solver struct (LM's
+      `mu`/`nu` precedent), not on state; one Hessian per outer iteration is
+      reused across an LM-style inner shrink loop (`with_max_inner_attempts`), so
+      rejected steps re-solve with smaller δ at zero extra derivative evals. New
+      `pub(crate)` `(g, B)` subproblem seam (`Subproblem` trait + `Step`),
+      distinct from the Powell `QuadraticModel` `TrustRegionSubproblem` seam
+      (different model type); shared `model_decrease` / `tau_to_boundary`
+      helpers. **v1 subproblems (all shipped):** `Steihaug` (matrix-free,
+      `MatVec` only --- all backends, wasm-clean; the default), `Dogleg`
+      (Cholesky Newton step via `LinearSolveSpd` + Cauchy fallback on indefinite
+      B --- all backends but ndarray), `CauchyPoint` (closed-form baseline,
       universal). v1 forms full B once per accepted iterate (Dogleg needs it
       anyway); a matrix-free `HessianProduct` trait so Steihaug needn't form B is
-      a future additive extension.
+      a future additive extension. Tests: Cauchy/Steihaug/Dogleg on
+      quadratic + Rosenbrock (analytic `DenseMatrix` Hessian), f32 round-trip,
+      `FiniteDiff` central-difference Hessian on nalgebra Rosenbrock. Web
+      catalogue + Backends notes updated.
   - **Deferred: Moré-Sorensen exact subproblem step.** The near-exact global
         solve (secular equation, hard case) via `SymmetricEigen` + Cholesky is
         out of v1 scope. It would require ingesting Moré & Sorensen (1983),

--- a/crates/basin/src/lib.rs
+++ b/crates/basin/src/lib.rs
@@ -161,6 +161,7 @@ pub use crate::core::termination::{
 pub use crate::line_search::{Backtracking, Constant, LineSearch, MoreThuente, Wolfe};
 pub use crate::solver::Bfgs;
 pub use crate::solver::lbfgs::{Lbfgs, Lbfgsb};
+pub use crate::solver::trust_region::{CauchyPoint, Dogleg, Steihaug, TrustRegion};
 pub use crate::solver::{
     AugmentedLagrangianMethod, BarrierMethod, Bobyqa, BoundedCmaEs, BoundedCmaInject, Brent,
     BrentDerivative, ClosureInner, CmaEs, CmaInject, Cobyla, De, DeInject, GaussNewton,

--- a/crates/basin/src/solver.rs
+++ b/crates/basin/src/solver.rs
@@ -87,6 +87,10 @@ pub mod lincoa;
 /// (simplex linear models + L-infinity merit + `trstlp`).
 pub mod cobyla;
 
+/// Trust-region Newton solver (Nocedal & Wright Algorithm 4.1) with
+/// pluggable subproblem strategies (Steihaug-CG, dogleg, Cauchy point).
+pub mod trust_region;
+
 pub use augmented_lagrangian_method::AugmentedLagrangianMethod;
 pub use barrier_method::BarrierMethod;
 pub use bfgs::Bfgs;
@@ -114,3 +118,4 @@ pub use random_search::RandomSearch;
 pub use sgd::Sgd;
 pub use ssga::Ssga;
 pub use trf::Trf;
+pub use trust_region::{CauchyPoint, Dogleg, Steihaug, TrustRegion};

--- a/crates/basin/src/solver/trust_region.rs
+++ b/crates/basin/src/solver/trust_region.rs
@@ -1,0 +1,593 @@
+//! Trust-region (Newton) minimization.
+//!
+//! [`TrustRegion`] is a general unconstrained minimizer over the
+//! second-order model `m(p) = f + gᵀp + ½ pᵀ B p`, where `g = ∇f(x)` and
+//! `B = ∇²f(x)` are supplied by the problem's
+//! [`Gradient`](crate::core::problem::Gradient) and [`Hessian`](crate::core::problem::Hessian) impls. Each iteration approximately
+//! minimizes `m` over a ball `‖p‖ ≤ Δ`, compares the achieved reduction to
+//! the model's prediction, and grows or shrinks the radius `Δ` accordingly
+//! (Nocedal & Wright, *Numerical Optimization*, 2e, Algorithm 4.1).
+//!
+//! The trust-region *subproblem* — the constrained quadratic minimization —
+//! is solved by a pluggable strategy implementing the crate-internal
+//! `Subproblem` seam. Three ship today, mirroring the standard textbook
+//! set:
+//!
+//! - [`Steihaug`] — truncated conjugate gradient (the default). Matrix-free
+//!   (needs only Hessian-vector products), handles indefinite `B` by
+//!   following a negative-curvature direction to the boundary. The
+//!   large-scale-capable workhorse; runs on every backend.
+//! - [`Dogleg`] — the Cauchy/Newton dogleg path (N&W eq. 4.16). Needs a
+//!   Cholesky solve for the Newton step, so it requires a backend with
+//!   [`LinearSolveSpd`](crate::core::math::LinearSolveSpd); it falls back to
+//!   the Cauchy point when `B` is not positive definite.
+//! - [`CauchyPoint`] — the steepest-descent-to-boundary closed form (N&W
+//!   eq. 4.11–4.12). A bulletproof baseline with only linear convergence;
+//!   mostly a reference strategy.
+
+pub mod dogleg;
+pub mod steihaug;
+
+pub use dogleg::Dogleg;
+pub use steihaug::Steihaug;
+
+use crate::core::math::{Dot, MatVec, NegInPlace, NormSquared, Scalar, ScaleInPlace, ScaledAdd};
+use crate::core::problem::{CostFunction, Gradient, Hessian, Problem};
+use crate::core::solver::Solver;
+use crate::core::state::BasicState;
+use crate::core::termination::TerminationReason;
+
+/// The outcome of an (approximate) trust-region subproblem solve: the step
+/// `d`, the predicted model decrease `m(0) − m(d) ≥ 0`, and whether the
+/// step landed on the trust-region boundary (which gates radius growth).
+pub(crate) struct Step<V, F> {
+    /// The step `d` (relative to the current iterate).
+    pub(crate) d: V,
+    /// Predicted reduction `m(0) − m(d) = −(gᵀd) − ½ dᵀBd`, always `≥ 0`
+    /// for the shipped strategies. Zero only when `d = 0` (gradient already
+    /// negligible), which the driver reads as convergence.
+    pub(crate) predicted_reduction: F,
+    /// `true` when `‖d‖ ≈ Δ` — the constraint is active. Only then may the
+    /// driver grow the radius on a very good step (N&W Algorithm 4.1).
+    pub(crate) hit_boundary: bool,
+}
+
+/// A strategy that approximately minimizes the quadratic model
+/// `m(p) = gᵀp + ½ pᵀ B p` over the trust region `‖p‖ ≤ radius`.
+///
+/// Crate-internal: the shipped strategies ([`Steihaug`], [`Dogleg`],
+/// [`CauchyPoint`]) are the closed set for now. Each binds `M` (the Hessian
+/// matrix type) on only the ops it needs — [`MatVec`] for the matrix-free
+/// strategies, plus [`LinearSolveSpd`](crate::core::math::LinearSolveSpd)
+/// for [`Dogleg`] — so a backend missing an op is a compile error for that
+/// strategy alone (tenet 5). Promoting this trait to public is an additive,
+/// non-breaking change if user-defined subproblem solvers are ever wanted.
+pub(crate) trait Subproblem<V, M, F> {
+    /// Approximately minimize `m(p) = gᵀp + ½ pᵀ B p` over `‖p‖ ≤ radius`.
+    fn solve(&self, gradient: &V, hessian: &M, radius: F) -> Step<V, F>;
+}
+
+/// Model decrease `m(0) − m(d) = −(gᵀd) − ½ dᵀBd` for the local quadratic
+/// model with gradient `g` and Hessian `B`. Shared by every subproblem
+/// strategy so the predicted-reduction convention lives in one place.
+pub(crate) fn model_decrease<V, M, F>(g: &V, b: &M, d: &V) -> F
+where
+    F: Scalar,
+    V: Dot<F>,
+    M: MatVec<V>,
+{
+    let bd = b.matvec(d);
+    let half = F::from_f64(0.5).unwrap();
+    -g.dot(d) - half * d.dot(&bd)
+}
+
+/// The largest `τ ≥ 0` with `‖z + τ d‖ = radius`: the positive root of the
+/// quadratic `‖z + τ d‖² = radius²`. Used to walk a CG iterate (Steihaug)
+/// or a negative-curvature direction out to the trust-region boundary.
+/// Assumes `z` lies inside the ball (`‖z‖ ≤ radius`), so the discriminant
+/// is non-negative; it is clamped to zero defensively against roundoff.
+pub(crate) fn tau_to_boundary<V, F>(z: &V, d: &V, radius: F) -> F
+where
+    F: Scalar,
+    V: Dot<F>,
+{
+    let dd = d.dot(d);
+    let zd = z.dot(d);
+    let zz = z.dot(z);
+    let rr = radius * radius;
+    let disc = zd * zd - dd * (zz - rr);
+    let disc = if disc < F::zero() { F::zero() } else { disc };
+    (-zd + disc.sqrt()) / dd
+}
+
+/// Cauchy-point subproblem strategy: minimize the model along the
+/// steepest-descent direction `−g`, capped at the trust-region boundary
+/// (Nocedal & Wright eq. 4.11–4.12).
+///
+/// The step is `p = −τ (Δ / ‖g‖) g`, with the scalar `τ` chosen to minimize
+/// the model along `−g` within the region: `τ = 1` when the curvature
+/// `gᵀBg ≤ 0` (the model decreases without bound, so go to the boundary),
+/// otherwise `τ = min(‖g‖³ / (Δ gᵀBg), 1)`. Robust but only linearly
+/// convergent — it ignores all curvature off the gradient direction. Useful
+/// as a baseline, and as [`Dogleg`]'s fallback when the Hessian is not
+/// positive definite.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CauchyPoint;
+
+impl<V, M, F> Subproblem<V, M, F> for CauchyPoint
+where
+    F: Scalar,
+    V: Clone + Dot<F> + NormSquared<F> + ScaleInPlace<F> + NegInPlace,
+    M: MatVec<V>,
+{
+    fn solve(&self, g: &V, b: &M, radius: F) -> Step<V, F> {
+        let g_norm = g.norm_squared().sqrt();
+        if g_norm <= F::zero() {
+            // Gradient already negligible: the zero step is optimal.
+            let mut d = g.clone();
+            d.scale_in_place(F::zero());
+            return Step {
+                d,
+                predicted_reduction: F::zero(),
+                hit_boundary: false,
+            };
+        }
+        let bg = b.matvec(g);
+        let gbg = g.dot(&bg);
+        let tau = if gbg <= F::zero() {
+            F::one()
+        } else {
+            let t = g_norm * g_norm * g_norm / (radius * gbg);
+            if t < F::one() { t } else { F::one() }
+        };
+        // p = −τ (Δ / ‖g‖) g.
+        let mut d = g.clone();
+        d.scale_in_place(-(tau * radius / g_norm));
+        let predicted_reduction = model_decrease(g, b, &d);
+        Step {
+            d,
+            predicted_reduction,
+            // τ = 1 ⟺ the step is the full Δ-length steepest-descent step,
+            // i.e. it sits on the boundary.
+            hit_boundary: tau >= F::one(),
+        }
+    }
+}
+
+/// Trust-region Newton minimizer (Nocedal & Wright, *Numerical
+/// Optimization*, 2e, §4 / Algorithm 4.1).
+///
+/// At each iterate `x` the local quadratic model
+/// `m(p) = f(x) + ∇f(x)ᵀp + ½ pᵀ ∇²f(x) p` is approximately minimized over a
+/// ball `‖p‖ ≤ Δ` by the configured `Subproblem` strategy. The ratio of
+/// achieved to predicted reduction,
+/// `ρ = (f(x) − f(x + p)) / (m(0) − m(p))`, drives the radius: `Δ` shrinks
+/// when `ρ` is poor (`< ¼`), grows when `ρ` is excellent (`> ¾`) and the
+/// step is constrained by the boundary, and the step is accepted when
+/// `ρ > η`. A rejected step shrinks `Δ` and re-solves the subproblem with
+/// the *same* gradient and Hessian — no extra derivative evaluations — up to
+/// [`with_max_inner_attempts`](Self::with_max_inner_attempts) times per
+/// outer iteration (the same reuse pattern as
+/// [`LevenbergMarquardt`](crate::solver::LevenbergMarquardt)).
+///
+/// The subproblem strategy defaults to [`Steihaug`] (truncated CG); choose
+/// another with [`with_subproblem`](Self::with_subproblem). The radius `Δ`
+/// is solver-internal working state — there are no framework termination
+/// knobs for it; pair the solver with
+/// [`GradientTolerance`](crate::core::termination::GradientTolerance) /
+/// [`MaxIter`](crate::core::termination::MaxIter) like any first-order
+/// solver.
+///
+/// # Backends
+///
+/// The solver itself needs only `Clone`, [`ScaledAdd`], and
+/// [`NormSquared`] on the parameter vector, plus a [`Hessian`] impl. The
+/// effective backend coverage is set by the chosen subproblem:
+/// [`Steihaug`] and [`CauchyPoint`] need only [`MatVec`] on the Hessian, so
+/// they run on every backend that has a dense matrix type (`Vec<f64>` via
+/// [`DenseMatrix`](crate::core::math::DenseMatrix), nalgebra, faer, and
+/// `ndarray`); [`Dogleg`] additionally needs
+/// [`LinearSolveSpd`](crate::core::math::LinearSolveSpd), which `ndarray`
+/// does not provide (a compile error there, per tenet 5). All shipped
+/// strategies are wasm-clean (pure-Rust, no BLAS/LAPACK).
+///
+/// Note that a [`Hessian`] is required: an analytic one from the problem, or
+/// a finite-difference one via
+/// [`FiniteDiff`](crate::core::numdiff::FiniteDiff) over a backend with a
+/// dense matrix type (nalgebra / faer).
+///
+/// # References
+///
+/// Nocedal, J., & Wright, S. J. (2006). *Numerical Optimization* (2nd ed.),
+/// Chapter 4 (trust-region methods). Springer.
+/// [doi:10.1007/978-0-387-40065-5](https://doi.org/10.1007/978-0-387-40065-5).
+///
+/// # Examples
+///
+/// Minimize the 2-D Rosenbrock function with an analytic Hessian over the
+/// nalgebra backend (the dense-matrix backend the example's `DMatrix`
+/// Hessian uses):
+///
+/// ```
+/// # #[cfg(feature = "nalgebra")] {
+/// use basin::{CostFunction, Executor, Gradient, GradientTolerance, Hessian, TrustRegion};
+/// use nalgebra::{DMatrix, DVector};
+///
+/// struct Rosenbrock;
+/// impl CostFunction for Rosenbrock {
+///     type Param = DVector<f64>;
+///     type Output = f64;
+///     type Error = std::convert::Infallible;
+///     fn cost(&self, x: &DVector<f64>) -> Result<f64, Self::Error> {
+///         Ok((1.0 - x[0]).powi(2) + 100.0 * (x[1] - x[0].powi(2)).powi(2))
+///     }
+/// }
+/// impl Gradient for Rosenbrock {
+///     type Gradient = DVector<f64>;
+///     fn gradient(&self, x: &DVector<f64>) -> Result<DVector<f64>, Self::Error> {
+///         Ok(DVector::from_vec(vec![
+///             -2.0 * (1.0 - x[0]) - 400.0 * x[0] * (x[1] - x[0].powi(2)),
+///             200.0 * (x[1] - x[0].powi(2)),
+///         ]))
+///     }
+/// }
+/// impl Hessian for Rosenbrock {
+///     type Hessian = DMatrix<f64>;
+///     fn hessian(&self, x: &DVector<f64>) -> Result<DMatrix<f64>, Self::Error> {
+///         let h11 = 2.0 - 400.0 * (x[1] - 3.0 * x[0].powi(2));
+///         Ok(DMatrix::from_row_slice(2, 2, &[
+///             h11, -400.0 * x[0],
+///             -400.0 * x[0], 200.0,
+///         ]))
+///     }
+/// }
+///
+/// let result = Executor::new(Rosenbrock, TrustRegion::new(), basin::BasicState::new(DVector::from_vec(vec![-1.2, 1.0])))
+///     .max_iter(100)
+///     .terminate_on(GradientTolerance(1e-8))
+///     .run()
+///     .unwrap();
+/// assert!(result.cost() < 1e-10);
+/// # }
+/// ```
+pub struct TrustRegion<Sub = Steihaug, F = f64> {
+    subproblem: Sub,
+    /// Current trust radius `Δ`, mutated across iterations. Reset to
+    /// `initial_radius` by [`Solver::init`].
+    radius: F,
+    initial_radius: F,
+    max_radius: F,
+    eta: F,
+    max_inner: u32,
+}
+
+impl Default for TrustRegion<Steihaug> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TrustRegion<Steihaug> {
+    /// Trust-region solver with the default [`Steihaug`] (truncated CG)
+    /// subproblem: initial radius `1.0`, maximum radius `100.0`, acceptance
+    /// threshold `η = 0.125`, and up to `10` radius reductions per outer
+    /// iteration.
+    pub fn new() -> Self {
+        Self::with_subproblem(Steihaug::new())
+    }
+}
+
+impl<Sub, F: Scalar> TrustRegion<Sub, F> {
+    /// Trust-region solver with an explicit subproblem strategy
+    /// ([`Steihaug`], [`Dogleg`], or [`CauchyPoint`]).
+    pub fn with_subproblem(subproblem: Sub) -> Self {
+        Self {
+            subproblem,
+            radius: F::one(),
+            initial_radius: F::one(),
+            max_radius: F::from_f64(100.0).unwrap(),
+            eta: F::from_f64(0.125).unwrap(),
+            max_inner: 10,
+        }
+    }
+
+    /// Initial trust radius `Δ₀` (default `1.0`). Must be positive. A good
+    /// `Δ₀` is the order of magnitude of the expected step to the minimum.
+    pub fn with_radius(mut self, radius: F) -> Self {
+        assert!(radius > F::zero(), "initial radius must be > 0");
+        self.initial_radius = radius;
+        self.radius = radius;
+        self
+    }
+
+    /// Upper bound on the trust radius `Δ_max` (default `100.0`). Must be
+    /// positive. Caps radius growth on a run of excellent steps.
+    pub fn with_max_radius(mut self, max_radius: F) -> Self {
+        assert!(max_radius > F::zero(), "max radius must be > 0");
+        self.max_radius = max_radius;
+        self
+    }
+
+    /// Step-acceptance threshold `η` (default `0.125`): a step is accepted
+    /// when the reduction ratio `ρ > η`. Nocedal & Wright require
+    /// `η ∈ [0, ¼)`; this is asserted.
+    pub fn with_eta(mut self, eta: F) -> Self {
+        assert!(
+            eta >= F::zero() && eta < F::from_f64(0.25).unwrap(),
+            "eta must be in [0, 1/4)"
+        );
+        self.eta = eta;
+        self
+    }
+
+    /// Maximum radius reductions per outer iteration (default `10`). Each
+    /// rejected step shrinks `Δ` and re-solves the subproblem with the same
+    /// gradient and Hessian; after this many rejections the iteration
+    /// returns the iterate unmoved with the shrunken radius, and the next
+    /// outer iteration retries. Must be `≥ 1`.
+    pub fn with_max_inner_attempts(mut self, n: u32) -> Self {
+        assert!(n >= 1, "max inner attempts must be ≥ 1");
+        self.max_inner = n;
+        self
+    }
+}
+
+impl<P, Sub, V, M, F> Solver<P, BasicState<V, F>> for TrustRegion<Sub, F>
+where
+    F: Scalar,
+    P: CostFunction<Param = V, Output = F> + Gradient<Gradient = V> + Hessian<Hessian = M>,
+    V: Clone + ScaledAdd<F> + NormSquared<F>,
+    Sub: Subproblem<V, M, F>,
+{
+    type Error = P::Error;
+
+    fn init(
+        &mut self,
+        problem: &mut Problem<P>,
+        mut state: BasicState<V, F>,
+    ) -> Result<BasicState<V, F>, Self::Error> {
+        // A reused solver instance must restart from the configured radius.
+        self.radius = self.initial_radius;
+        // Seed cost and gradient so iter-0 termination checks (e.g.
+        // GradientTolerance on a near-optimal start) see a complete state.
+        // The Hessian is recomputed per iteration in `next_iter`, so it is
+        // not seeded here.
+        let (cost, grad) = problem.cost_and_gradient(&state.param)?;
+        state.cost = Some(cost);
+        state.gradient = Some(grad);
+        Ok(state)
+    }
+
+    fn next_iter(
+        &mut self,
+        problem: &mut Problem<P>,
+        mut state: BasicState<V, F>,
+    ) -> Result<(BasicState<V, F>, Option<TerminationReason>), Self::Error> {
+        let g = state
+            .gradient
+            .take()
+            .expect("gradient not set: Solver::init must run before next_iter");
+        let cost_old = state
+            .cost
+            .expect("cost not set: Solver::init must run before next_iter");
+
+        // One Hessian per outer iteration, reused across all inner radius
+        // reductions below (the gradient is likewise fixed while x is).
+        let b = problem.hessian(&state.param)?;
+
+        let quarter = F::from_f64(0.25).unwrap();
+        let three_quarters = F::from_f64(0.75).unwrap();
+        let two = F::from_f64(2.0).unwrap();
+
+        for _ in 0..self.max_inner {
+            let step = self.subproblem.solve(&g, &b, self.radius);
+
+            // Predicted reduction ≤ 0 means the model cannot decrease — for
+            // the shipped strategies this only happens at a stationary point
+            // (g ≈ 0). Report a clean convergence stop.
+            if step.predicted_reduction <= F::zero() {
+                state.gradient = Some(g);
+                return Ok((state, Some(TerminationReason::SolverConverged)));
+            }
+
+            let mut trial = state.param.clone();
+            trial.scaled_add(F::one(), &step.d);
+            let cost_trial = problem.cost(&trial)?;
+
+            let rho = (cost_old - cost_trial) / step.predicted_reduction;
+            let step_norm = step.d.norm_squared().sqrt();
+
+            // Radius update (N&W Algorithm 4.1). A non-finite ρ (trial cost
+            // Inf/NaN from a soft rejection) routes to the shrink branch, so
+            // the radius always decreases on a bad step and the inner loop
+            // can't stall.
+            //
+            // The shrink uses ¼‖p‖ rather than the literal ¼Δ of Algorithm
+            // 4.1: the two agree for a boundary step (‖p‖ ≈ Δ) but ¼‖p‖
+            // shrinks harder on a rejected *interior* step, anchoring the new
+            // radius to the step the model actually mispredicted. This
+            // follows argmin's `TrustRegion` (0.25 * pk_norm); deliberate, not
+            // the textbook ¼Δ.
+            if rho < quarter || !rho.is_finite() {
+                self.radius = quarter * step_norm;
+            } else if rho > three_quarters && step.hit_boundary {
+                let grown = two * self.radius;
+                self.radius = if grown < self.max_radius {
+                    grown
+                } else {
+                    self.max_radius
+                };
+            }
+
+            if rho > self.eta {
+                // Accept: move to the trial point and refresh the gradient
+                // there (the Hessian is recomputed by the next iteration).
+                state.param = trial;
+                state.cost = Some(cost_trial);
+                let g_new = problem.gradient(&state.param)?;
+                state.gradient = Some(g_new);
+                return Ok((state, None));
+            }
+            // Reject: radius has shrunk; retry with the same g and b.
+        }
+
+        // Inner attempts exhausted without an acceptable step. Keep the
+        // shrunken radius and the current iterate; restore the gradient so
+        // the state stays consistent and let the next outer iteration retry
+        // (or a termination criterion fire).
+        state.gradient = Some(g);
+        Ok((state, None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BasicState, Executor, GradientTolerance};
+
+    /// Ill-conditioned quadratic `f(x) = ½ xᵀ A x` with `A = diag(1, 100)`,
+    /// gradient `A x`, constant Hessian `A`. A single Newton step solves it
+    /// exactly, so any curvature-aware trust-region run reaches the origin
+    /// fast.
+    struct Quadratic;
+
+    impl CostFunction for Quadratic {
+        type Param = Vec<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &Vec<f64>) -> Result<f64, Self::Error> {
+            Ok(0.5 * (x[0] * x[0] + 100.0 * x[1] * x[1]))
+        }
+    }
+    impl Gradient for Quadratic {
+        type Gradient = Vec<f64>;
+        fn gradient(&self, x: &Vec<f64>) -> Result<Vec<f64>, Self::Error> {
+            Ok(vec![x[0], 100.0 * x[1]])
+        }
+    }
+    impl Hessian for Quadratic {
+        type Hessian = crate::core::math::DenseMatrix<f64>;
+        fn hessian(&self, _x: &Vec<f64>) -> Result<Self::Hessian, Self::Error> {
+            Ok(crate::core::math::DenseMatrix::from_row_slice(
+                2,
+                2,
+                &[1.0, 0.0, 0.0, 100.0],
+            ))
+        }
+    }
+
+    /// 2-D Rosenbrock with an analytic Hessian over the dependency-free
+    /// `Vec<f64>` backend (`DenseMatrix`). The classic nonconvex test: the
+    /// Hessian is indefinite far from the valley floor, so it exercises the
+    /// curvature handling of every subproblem.
+    struct Rosenbrock;
+
+    impl CostFunction for Rosenbrock {
+        type Param = Vec<f64>;
+        type Output = f64;
+        type Error = std::convert::Infallible;
+        fn cost(&self, x: &Vec<f64>) -> Result<f64, Self::Error> {
+            Ok((1.0 - x[0]).powi(2) + 100.0 * (x[1] - x[0].powi(2)).powi(2))
+        }
+    }
+    impl Gradient for Rosenbrock {
+        type Gradient = Vec<f64>;
+        fn gradient(&self, x: &Vec<f64>) -> Result<Vec<f64>, Self::Error> {
+            Ok(vec![
+                -2.0 * (1.0 - x[0]) - 400.0 * x[0] * (x[1] - x[0].powi(2)),
+                200.0 * (x[1] - x[0].powi(2)),
+            ])
+        }
+    }
+    impl Hessian for Rosenbrock {
+        type Hessian = crate::core::math::DenseMatrix<f64>;
+        fn hessian(&self, x: &Vec<f64>) -> Result<Self::Hessian, Self::Error> {
+            let h11 = 2.0 + 1200.0 * x[0] * x[0] - 400.0 * x[1];
+            let h12 = -400.0 * x[0];
+            Ok(crate::core::math::DenseMatrix::from_row_slice(
+                2,
+                2,
+                &[h11, h12, h12, 200.0],
+            ))
+        }
+    }
+
+    #[test]
+    fn cauchy_point_minimizes_quadratic() {
+        let result = Executor::new(
+            Quadratic,
+            TrustRegion::with_subproblem(CauchyPoint),
+            BasicState::new(vec![5.0, 1.0]),
+        )
+        .max_iter(500)
+        .terminate_on(GradientTolerance(1e-8))
+        .run()
+        .unwrap();
+        // Cauchy point is only linearly convergent on this conditioning, so
+        // a strong-but-not-machine-precision bound is the honest check.
+        assert!(result.cost() < 1e-8, "cost = {}", result.cost());
+    }
+
+    #[test]
+    fn steihaug_minimizes_quadratic() {
+        // Truncated CG is curvature-aware: it reaches the minimizer of a
+        // quadratic to machine precision in a handful of iterations.
+        let result = Executor::new(
+            Quadratic,
+            TrustRegion::with_subproblem(Steihaug::new()),
+            BasicState::new(vec![5.0, 1.0]),
+        )
+        .max_iter(100)
+        .terminate_on(GradientTolerance(1e-10))
+        .run()
+        .unwrap();
+        assert!(result.cost() < 1e-16, "cost = {}", result.cost());
+    }
+
+    #[test]
+    fn dogleg_minimizes_quadratic() {
+        let result = Executor::new(
+            Quadratic,
+            TrustRegion::with_subproblem(Dogleg),
+            BasicState::new(vec![5.0, 1.0]),
+        )
+        .max_iter(100)
+        .terminate_on(GradientTolerance(1e-10))
+        .run()
+        .unwrap();
+        assert!(result.cost() < 1e-16, "cost = {}", result.cost());
+    }
+
+    #[test]
+    fn steihaug_minimizes_rosenbrock() {
+        // The default subproblem on the canonical nonconvex problem, from
+        // the standard hard start. Indefinite Hessians along the way are
+        // handled by the negative-curvature-to-boundary rule.
+        let result = Executor::new(
+            Rosenbrock,
+            TrustRegion::new(),
+            BasicState::new(vec![-1.2, 1.0]),
+        )
+        .max_iter(200)
+        .terminate_on(GradientTolerance(1e-8))
+        .run()
+        .unwrap();
+        assert!(result.cost() < 1e-10, "cost = {}", result.cost());
+    }
+
+    #[test]
+    fn dogleg_minimizes_rosenbrock() {
+        // Dogleg falls back to the Cauchy point wherever the Hessian is
+        // indefinite, so it still drives Rosenbrock to the minimum.
+        let result = Executor::new(
+            Rosenbrock,
+            TrustRegion::with_subproblem(Dogleg),
+            BasicState::new(vec![-1.2, 1.0]),
+        )
+        .max_iter(500)
+        .terminate_on(GradientTolerance(1e-8))
+        .run()
+        .unwrap();
+        assert!(result.cost() < 1e-10, "cost = {}", result.cost());
+    }
+}

--- a/crates/basin/src/solver/trust_region/dogleg.rs
+++ b/crates/basin/src/solver/trust_region/dogleg.rs
@@ -1,0 +1,103 @@
+//! Dogleg trust-region subproblem.
+
+use super::{CauchyPoint, Step, Subproblem, model_decrease, tau_to_boundary};
+use crate::core::math::{
+    Dot, LinearSolveSpd, MatVec, NegInPlace, NormSquared, Scalar, ScaleInPlace, ScaledAdd,
+};
+
+/// Dogleg subproblem solver (Nocedal & Wright, *Numerical Optimization*, 2e,
+/// eq. 4.16; Powell 1970).
+///
+/// Approximates the trust-region step by a two-segment path: from the origin
+/// to the unconstrained Cauchy minimizer `p_U = −(gᵀg / gᵀBg) g`, then on to
+/// the full Newton step `p_B = −B⁻¹g`. The returned step is the point where
+/// this path first reaches radius `Δ` (or `p_B` itself when it lies inside
+/// the region).
+///
+/// The Newton step requires a Cholesky solve, so the Hessian type must
+/// implement [`LinearSolveSpd`]; when the Hessian is **not** positive
+/// definite (factorization fails) the geometry of the dogleg path breaks
+/// down and this strategy falls back to the [`CauchyPoint`] step. For
+/// problems with frequently indefinite Hessians prefer [`Steihaug`], which
+/// handles negative curvature directly.
+///
+/// [`Steihaug`]: super::Steihaug
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Dogleg;
+
+impl<V, M, F> Subproblem<V, M, F> for Dogleg
+where
+    F: Scalar,
+    V: Clone + Dot<F> + NormSquared<F> + ScaledAdd<F> + ScaleInPlace<F> + NegInPlace,
+    M: MatVec<V> + LinearSolveSpd<V>,
+{
+    fn solve(&self, g: &V, b: &M, radius: F) -> Step<V, F> {
+        // Full Newton step p_B = −B⁻¹ g. A non-SPD Hessian makes the dogleg
+        // geometry invalid, so defer to the Cauchy point there.
+        let p_b = match b.solve_spd(g) {
+            Ok(mut p) => {
+                p.neg_in_place();
+                p
+            }
+            Err(_) => return CauchyPoint.solve(g, b, radius),
+        };
+        let p_b_norm = p_b.norm_squared().sqrt();
+        if p_b_norm <= radius {
+            // Newton step is inside the region: take it whole.
+            let predicted_reduction = model_decrease(g, b, &p_b);
+            return Step {
+                d: p_b,
+                predicted_reduction,
+                hit_boundary: p_b_norm >= radius,
+            };
+        }
+
+        // Cauchy minimizer along −g: p_U = −(gᵀg / gᵀBg) g.
+        let bg = b.matvec(g);
+        let gbg = g.dot(&bg);
+        let gg = g.dot(g);
+        // With an SPD B the Newton solve above succeeded and gᵀBg > 0; this
+        // guard covers only pathological roundoff, walking to the boundary
+        // along steepest descent.
+        if gbg <= F::zero() {
+            let mut d = g.clone();
+            d.scale_in_place(-(radius / gg.sqrt()));
+            let predicted_reduction = model_decrease(g, b, &d);
+            return Step {
+                d,
+                predicted_reduction,
+                hit_boundary: true,
+            };
+        }
+
+        let mut p_u = g.clone();
+        p_u.scale_in_place(-(gg / gbg));
+        let p_u_norm = p_u.norm_squared().sqrt();
+        if p_u_norm >= radius {
+            // The Cauchy point is already outside the region: clip the
+            // steepest-descent step to the boundary.
+            let mut d = g.clone();
+            d.scale_in_place(-(radius / gg.sqrt()));
+            let predicted_reduction = model_decrease(g, b, &d);
+            return Step {
+                d,
+                predicted_reduction,
+                hit_boundary: true,
+            };
+        }
+
+        // Second leg: walk from p_U toward p_B until ‖·‖ = Δ. With p_U inside
+        // and p_B outside the region, the crossing parameter τ lies in (0, 1).
+        let mut diff = p_b;
+        diff.scaled_add(-F::one(), &p_u); // diff = p_B − p_U
+        let tau = tau_to_boundary(&p_u, &diff, radius);
+        let mut d = p_u;
+        d.scaled_add(tau, &diff);
+        let predicted_reduction = model_decrease(g, b, &d);
+        Step {
+            d,
+            predicted_reduction,
+            hit_boundary: true,
+        }
+    }
+}

--- a/crates/basin/src/solver/trust_region/steihaug.rs
+++ b/crates/basin/src/solver/trust_region/steihaug.rs
@@ -1,0 +1,152 @@
+//! Steihaug truncated conjugate-gradient trust-region subproblem.
+
+use super::{Step, Subproblem, model_decrease, tau_to_boundary};
+use crate::core::math::{
+    Dot, MatVec, NegInPlace, NormSquared, Scalar, ScaleInPlace, ScaledAdd, VectorLen,
+};
+
+/// Steihaug truncated conjugate-gradient subproblem solver (Nocedal &
+/// Wright, *Numerical Optimization*, 2e, Algorithm 7.2; Steihaug 1983).
+///
+/// Runs conjugate gradient on the model `m(p) = gᵀp + ½ pᵀ B p`, truncating
+/// as soon as it (a) generates a direction of non-positive curvature
+/// `dᵀBd ≤ 0`, or (b) would step outside the trust region. In either case it
+/// follows the current direction to the boundary and stops; otherwise it
+/// converges to the unconstrained model minimizer inside the region, with a
+/// residual tolerance `ε = min(½, √‖g‖) · ‖g‖` (the standard forcing
+/// sequence). Matrix-free — it touches the Hessian only through
+/// [`MatVec`] (Hessian-vector products) — so it runs on every backend and
+/// scales to large, possibly indefinite problems.
+///
+/// This is [`TrustRegion`](super::TrustRegion)'s default subproblem.
+#[derive(Debug, Clone, Copy)]
+pub struct Steihaug {
+    /// CG iteration cap; `None` uses the problem dimension `n` (CG's natural
+    /// bound for exact arithmetic).
+    max_iter: Option<usize>,
+}
+
+impl Steihaug {
+    /// Steihaug truncated CG with the default iteration cap (the problem
+    /// dimension `n`).
+    pub fn new() -> Self {
+        Self { max_iter: None }
+    }
+
+    /// Cap the number of CG iterations per subproblem solve. By default the
+    /// cap is the problem dimension `n`; lowering it yields a cheaper, looser
+    /// step. Must be `≥ 1`.
+    pub fn with_max_iter(mut self, n: usize) -> Self {
+        assert!(n >= 1, "max_iter must be ≥ 1");
+        self.max_iter = Some(n);
+        self
+    }
+}
+
+impl Default for Steihaug {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V, M, F> Subproblem<V, M, F> for Steihaug
+where
+    F: Scalar,
+    V: Clone + Dot<F> + NormSquared<F> + ScaledAdd<F> + ScaleInPlace<F> + NegInPlace + VectorLen,
+    M: MatVec<V>,
+{
+    fn solve(&self, g: &V, b: &M, radius: F) -> Step<V, F> {
+        let n = g.vec_len();
+        let max_iter = self.max_iter.unwrap_or(n.max(1));
+
+        // z₀ = 0, r₀ = g, d₀ = −r₀.
+        let mut z = g.clone();
+        z.scale_in_place(F::zero());
+        let mut r = g.clone();
+        let mut r_dot = r.dot(&r);
+
+        // Forcing tolerance ε = min(½, √‖g‖) · ‖g‖.
+        let g_norm = r_dot.sqrt();
+        let half = F::from_f64(0.5).unwrap();
+        let s = g_norm.sqrt();
+        let tol = (if s < half { s } else { half }) * g_norm;
+
+        // Only triggers for g ≈ 0 (ε ≥ ‖g‖ is impossible otherwise): the
+        // zero step, which the driver reads as convergence.
+        if g_norm <= tol {
+            let predicted_reduction = model_decrease(g, b, &z);
+            return Step {
+                d: z,
+                predicted_reduction,
+                hit_boundary: false,
+            };
+        }
+
+        let mut d = r.clone();
+        d.neg_in_place();
+
+        for _ in 0..max_iter {
+            let bd = b.matvec(&d);
+            let dbd = d.dot(&bd);
+
+            // Non-positive curvature: the model is unbounded along ±d, so
+            // walk to the trust-region boundary and stop.
+            if dbd <= F::zero() {
+                let tau = tau_to_boundary(&z, &d, radius);
+                z.scaled_add(tau, &d);
+                let predicted_reduction = model_decrease(g, b, &z);
+                return Step {
+                    d: z,
+                    predicted_reduction,
+                    hit_boundary: true,
+                };
+            }
+
+            let alpha = r_dot / dbd;
+
+            // Tentative CG iterate z + α d. If it leaves the region, clip to
+            // the boundary along d instead.
+            let mut z_next = z.clone();
+            z_next.scaled_add(alpha, &d);
+            if z_next.norm_squared().sqrt() >= radius {
+                let tau = tau_to_boundary(&z, &d, radius);
+                z.scaled_add(tau, &d);
+                let predicted_reduction = model_decrease(g, b, &z);
+                return Step {
+                    d: z,
+                    predicted_reduction,
+                    hit_boundary: true,
+                };
+            }
+            z = z_next;
+
+            // r ← r + α B d; converged inside the region once it is small.
+            r.scaled_add(alpha, &bd);
+            let r_dot_next = r.dot(&r);
+            if r_dot_next.sqrt() < tol {
+                let predicted_reduction = model_decrease(g, b, &z);
+                return Step {
+                    d: z,
+                    predicted_reduction,
+                    hit_boundary: false,
+                };
+            }
+
+            // d ← −r + β d.
+            let beta = r_dot_next / r_dot;
+            let mut d_next = r.clone();
+            d_next.neg_in_place();
+            d_next.scaled_add(beta, &d);
+            d = d_next;
+            r_dot = r_dot_next;
+        }
+
+        // Iteration cap reached: return the best interior iterate so far.
+        let predicted_reduction = model_decrease(g, b, &z);
+        Step {
+            d: z,
+            predicted_reduction,
+            hit_boundary: false,
+        }
+    }
+}

--- a/crates/basin/tests/f32_round_trip.rs
+++ b/crates/basin/tests/f32_round_trip.rs
@@ -3,15 +3,16 @@
 //! provisional-choice trigger from `CONTRIBUTING.md` is now satisfiable: the
 //! whole pipeline runs at a non-`f64` scalar without further refactor.
 
-use basin::GradientDescent;
 use basin::core::executor::Executor;
-use basin::core::problem::{CostFunction, Gradient};
+use basin::core::math::DenseMatrix;
+use basin::core::problem::{CostFunction, Gradient, Hessian};
 use basin::core::state::{BasicState, LbfgsState, State};
 use basin::core::termination::{
     CostTolerance, GradientTolerance, MaxIter, RelativeCostTolerance, TargetCost,
 };
 use basin::line_search::{Backtracking, MoreThuente};
 use basin::solver::lbfgs::{Lbfgs, Unbounded};
+use basin::{GradientDescent, Steihaug, TrustRegion};
 
 /// `f(x) = ‖x − c‖²` with `c = (1, 2, 3)`. Minimum at `c`, cost 0.
 struct ShiftedQuadF32 {
@@ -70,6 +71,40 @@ fn unbounded_lbfgs_f32_round_trips_state_solver_termination() {
         .terminate_on(CostTolerance::<f32>::new(1e-6))
         .terminate_on(RelativeCostTolerance::<f32>::new(1e-6))
         .terminate_on(TargetCost::<f32>(1e-6))
+        .run()
+        .unwrap();
+
+    let final_x = result.state.param();
+    assert!((final_x[0] - 1.0).abs() < 1e-3);
+    assert!((final_x[1] - 2.0).abs() < 1e-3);
+    assert!((final_x[2] - 3.0).abs() < 1e-3);
+}
+
+impl Hessian for ShiftedQuadF32 {
+    type Hessian = DenseMatrix<f32>;
+    fn hessian(&self, _x: &Vec<f32>) -> Result<DenseMatrix<f32>, Self::Error> {
+        // f(x) = Σ (xᵢ − cᵢ)², so ∇²f = 2 I.
+        Ok(DenseMatrix::from_fn(
+            3,
+            3,
+            |i, j| if i == j { 2.0 } else { 0.0 },
+        ))
+    }
+}
+
+#[test]
+fn trust_region_f32_round_trips_state_solver_termination() {
+    // The whole second-order pipeline (Hessian trait, DenseMatrix<f32>
+    // matvec, Steihaug CG) runs end-to-end at F = f32 over Vec<f32>.
+    let problem = ShiftedQuadF32 {
+        c: vec![1.0_f32, 2.0, 3.0],
+    };
+    let state = BasicState::<Vec<f32>, f32>::new(vec![0.0_f32; 3]);
+    let solver: TrustRegion<Steihaug, f32> = TrustRegion::with_subproblem(Steihaug::new());
+
+    let result = Executor::new(problem, solver, state)
+        .terminate_on(MaxIter(100))
+        .terminate_on(GradientTolerance::<f32>(1e-4))
         .run()
         .unwrap();
 

--- a/crates/basin/tests/numdiff.rs
+++ b/crates/basin/tests/numdiff.rs
@@ -33,9 +33,36 @@ fn gradient_descent_on_finite_diff_sphere_converges() {
 
 #[cfg(feature = "nalgebra")]
 mod nalgebra {
-    use basin::problems::RosenbrockResiduals;
-    use basin::{Executor, FiniteDiff, LevenbergMarquardt, NllsState, TerminationReason};
+    use basin::problems::{Rosenbrock, RosenbrockResiduals};
+    use basin::{
+        BasicState, Executor, FiniteDiff, GradientTolerance, LevenbergMarquardt, Method, NllsState,
+        TerminationReason, TrustRegion,
+    };
     use nalgebra::DVector;
+
+    #[test]
+    fn trust_region_on_finite_diff_hessian_minimizes_rosenbrock() {
+        // Rosenbrock exposes only `cost`; `FiniteDiff` supplies both the
+        // gradient and the (central-difference) Hessian the trust-region
+        // Newton solver consumes. The FD Hessian is only ~√ε accurate, so a
+        // strong-but-not-machine-precision bound is the honest check.
+        let problem =
+            FiniteDiff::new(Rosenbrock::<DVector<f64>>::new()).hessian_method(Method::Central);
+
+        let result = Executor::new(
+            problem,
+            TrustRegion::new(),
+            BasicState::new(DVector::from_vec(vec![-1.2, 1.0])),
+        )
+        .max_iter(300)
+        .terminate_on(GradientTolerance(1e-6))
+        .run()
+        .unwrap();
+
+        assert!(result.cost() < 1e-8, "cost = {}", result.cost());
+        assert!((result.param()[0] - 1.0).abs() < 1e-3);
+        assert!((result.param()[1] - 1.0).abs() < 1e-3);
+    }
 
     #[test]
     fn levenberg_marquardt_on_finite_diff_jacobian_matches_analytic() {

--- a/web/src/routes/docs/solvers/+page.svx
+++ b/web/src/routes/docs/solvers/+page.svx
@@ -89,6 +89,15 @@ trailing note cites the paper it implements (or the source it ports).
   Fortran source (Byrd, Lu & Nocedal, 1995; Zhu, Byrd, Lu & Nocedal, 1997,
   ACM TOMS Alg. 778).
 
+## Trust region
+
+For problems exposing a `Hessian` (analytic, or synthesized by `FiniteDiff`):
+
+- **[`TrustRegion`](https://docs.rs/basin/latest/basin/solver/trust_region/struct.TrustRegion.html)**
+  — second-order trust-region Newton minimizer (Nocedal & Wright, 2006,
+  Alg. 4.1). The subproblem strategy is pluggable: `Steihaug` (truncated CG,
+  the default), `Dogleg`, or `CauchyPoint`.
+
 ## Nonlinear least squares
 
 For problems expressed as residuals (`Residual` + `Jacobian`):
@@ -193,6 +202,7 @@ parameter type, ✗ means it is a compile-time error (the tiering rule above).
 | `Bfgs` | Quasi-Newton | ✓ | ✓ | ✗ | ✓ |
 | `Lbfgs` | Quasi-Newton | ✓ | ✓ | ✓ | ✓ |
 | `Lbfgsb` | Quasi-Newton | ✓ | ✓ | ✓ | ✓ |
+| `TrustRegion` | Trust region | ✓ | ✓ | ✓‡ | ✓ |
 | `GaussNewton` | Least squares | ✓ | ✓ | ✗ | ✓ |
 | `LevenbergMarquardt` | Least squares | ✓ | ✓ | ✗ | ✓ |
 | `Trf` | Least squares | ✗ | ✓ | ✗ | ✓ |
@@ -214,6 +224,13 @@ interval (1-D), so the vector-backend choice does not apply.
 † `DeInject` is itself backend-generic, but its effective coverage is the
 intersection of `De` and the chosen inner solver: a `LevenbergMarquardt` or
 `Lbfgsb` inner narrows it to nalgebra / faer.
+
+‡ `TrustRegion`'s coverage depends on the subproblem strategy: `Steihaug`
+(the default) and `CauchyPoint` need only matrix-vector products, so they run
+on every backend; `Dogleg` additionally needs a Cholesky solve
+(`LinearSolveSpd`), which `ndarray` does not provide. On `ndarray` the Hessian
+must be supplied analytically as an `Array2<f64>` — `FiniteDiff` cannot
+synthesize one there (no dense-matrix constructor).
 
 Each solver's page on [docs.rs](https://docs.rs/basin) carries a **Backends**
 note listing exactly which parameter types it supports.


### PR DESCRIPTION
## Summary

A general unconstrained second-order minimizer consuming the `Hessian` trait — the consumer that trait and `FiniteDiff` were added ahead of.

`TrustRegion<Sub, F>` drives **Nocedal & Wright Algorithm 4.1** over `BasicState`: each iteration approximately minimizes the local quadratic model `m(p) = f + gᵀp + ½ pᵀBp` over a trust ball `‖p‖ ≤ Δ`, compares achieved to predicted reduction, and grows/shrinks `Δ`. The radius lives in the solver struct (LM's `mu`/`nu` precedent); one Hessian per outer iteration is reused across an LM-style inner shrink loop, so **rejected steps re-solve at zero extra derivative evaluations**.

The subproblem is a pluggable `pub(crate)` `Subproblem` seam over a general `(g, B)` model — distinct from the Powell `QuadraticModel` seam. Three strategies ship:

- **`Steihaug`** — truncated CG, matrix-free (`MatVec` only), the **default**; runs on every backend, handles indefinite Hessians via negative-curvature-to-boundary.
- **`Dogleg`** — Cauchy/Newton path (N&W eq. 4.16); needs `LinearSolveSpd`, falls back to the Cauchy point on an indefinite Hessian.
- **`CauchyPoint`** — steepest-descent-to-boundary closed form (baseline / Dogleg fallback).

## Design notes

- Anchored to **N&W Ch. 4** and the in-repo **TRSAPP** truncated-CG (NEWUOA) — modeled on argmin's structure, **not a port**. gomez's TrustRegion was rejected as a model (it's an `f(x)=0` root-finder, overlapping LM/`Trf`).
- **Backends:** Steihaug/Cauchy on all four (`Vec<f64>`, nalgebra, ndarray, faer); Dogleg on all but ndarray (no `LinearSolveSpd`). All wasm-clean.
- **Moré-Sorensen exact step is deferred** (would require ingesting Moré & Sorensen 1983) — tracked in `TODO.md`.

## Tests

- The three strategies on an ill-conditioned quadratic and Rosenbrock (analytic `DenseMatrix` Hessian).
- `f32` round-trip end-to-end over `Vec<f32>`.
- `FiniteDiff` central-difference Hessian driving nalgebra Rosenbrock to <1e-8.

## Verification

479 lib tests + integration tests pass; `clippy --all-targets --all-features` clean; `cargo doc --all-features` clean (no broken links); wasm build and web catalogue build pass. Web solver catalogue + per-solver Backends notes updated.