### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "ea1164bf52f458f230d268d39be28d31ea7134d0",
+  "baseline-sha": "67b38d81b5d55ee4dfbaa198acb910e561c3b181",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.2.0",
-      "tag": "v1.2.0"
+      "version": "1.3.0",
+      "tag": "v1.3.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.2.0",
-      "tag": "v1.2.0"
+      "version": "1.3.0",
+      "tag": "v1.3.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.3.0](https://github.com/jolars/basin/compare/v1.2.0...v1.3.0) (2026-06-24)
+
+### Features
+- add the least-squares family to ndarray (+ Trf on Vec<f64>) ([`67b38d8`](https://github.com/jolars/basin/commit/67b38d81b5d55ee4dfbaa198acb910e561c3b181))
+- add Bfgs support for the ndarray backend ([`f2c50ba`](https://github.com/jolars/basin/commit/f2c50ba5b7bc5e2538f520c043b8951a678326c0))
+
+### Bug Fixes
+- **security:** bump esbuild ([`60c2b73`](https://github.com/jolars/basin/commit/60c2b73fe6dd1ea40bf7141e0e75368a34e2857d))
+
 ## [1.2.0](https://github.com/jolars/basin/compare/v1.1.0...v1.2.0) (2026-06-22)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "criterion",
  "faer",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "competitor-bench"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -915,9 +915,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1916,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1952,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "1.2.0"
+version = "1.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "1.2.0"
+version = "1.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM / GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "1.2.0"
+version = "1.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [1.3.0](https://github.com/jolars/basin/compare/v1.2.0...v1.3.0) (2026-06-24)

### Features
- add the least-squares family to ndarray (+ Trf on Vec<f64>) ([`67b38d8`](https://github.com/jolars/basin/commit/67b38d81b5d55ee4dfbaa198acb910e561c3b181))
- add Bfgs support for the ndarray backend ([`f2c50ba`](https://github.com/jolars/basin/commit/f2c50ba5b7bc5e2538f520c043b8951a678326c0))

### Bug Fixes
- **security:** bump esbuild ([`60c2b73`](https://github.com/jolars/basin/commit/60c2b73fe6dd1ea40bf7141e0e75368a34e2857d))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).