### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "574fe22822c54d5746d3047628e5c59e069fbec3",
+  "baseline-sha": "2e65754cbdc714bcd253c4585389e7250353a5ca",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.6.0",
-      "tag": "v1.6.0"
+      "version": "1.7.0",
+      "tag": "v1.7.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.6.0",
-      "tag": "v1.6.0"
+      "version": "1.7.0",
+      "tag": "v1.7.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.7.0](https://github.com/jolars/basin/compare/v1.6.0...v1.7.0) (2026-08-27)
+
+### Features
+- add phase one to barrier method ([`776850d`](https://github.com/jolars/basin/commit/776850d23a38a6a4471e83856bf2987137e62941))
+
 ## [1.6.0](https://github.com/jolars/basin/compare/v1.5.1...v1.6.0) (2026-08-25)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "competitor-bench"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "argmin",
  "argmin-math",

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "1.6.0"
+version = "1.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "1.6.0"
+version = "1.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM/GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "1.6.0"
+version = "1.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [1.7.0](https://github.com/jolars/basin/compare/v1.6.0...v1.7.0) (2026-08-27)

### Features
- add phase one to barrier method ([`776850d`](https://github.com/jolars/basin/commit/776850d23a38a6a4471e83856bf2987137e62941))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).