### PR TITLE
feat: export Trf damping traits for custom Jacobians

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- export `AddDiagonalVectorInPlace` and `MaxDiagonal` so out-of-tree `Trf` Jacobian types can implement the damped Gram path
+
 ## [1.7.0](https://github.com/jolars/basin/compare/v1.6.0...v1.7.0) (2026-08-27)
 
 ### Features

--- a/crates/basin/src/core/math.rs
+++ b/crates/basin/src/core/math.rs
@@ -19,11 +19,12 @@
 //!   a second exception: [`DenseMatrix`] implements it via a pure-Rust
 //!   cyclic Jacobi eigensolver (`dense_eig`), so CMA-ES runs on the default
 //!   backend too. The SPD solve [`LinearSolveSpd`] and its companion
-//!   [`GramMatrix`] (plus the `pub(crate)` `AddDiagonalVectorInPlace`) are a
+//!   [`GramMatrix`] (plus [`AddDiagonalVectorInPlace`]) are a
 //!   third: [`DenseMatrix`] implements them via a pure-Rust Cholesky
 //!   (`dense_chol`), so Gauss-Newton and Levenberg-Marquardt run on the
-//!   default backend. The QR least-squares solve [`LinearSolveLstsq`] (and the
-//!   trust-region-reflective `MaxDiagonal`) stay nalgebra- and faer-only.
+//!   default backend. The QR least-squares solve [`LinearSolveLstsq`] stays
+//!   nalgebra- and faer-only. [`MaxDiagonal`] is public so custom `Trf`
+//!   Jacobian types can implement the same damping path as the shipped backends.
 
 /// Scalar element type for vectors and matrices in the math layer.
 ///
@@ -250,19 +251,16 @@ mod faer_sparse_backend;
 pub use clamp::ClampInPlace;
 pub use dense::DenseMatrix;
 pub use linalg::{
-    DenseMatrixFromFn, GramMatrix, LinearSolveError, LinearSolveLstsq,
-    LinearSolveSpd, MatTransposeVec, MatVec, MatrixFromDiagonal,
-    MatrixIdentity, SymmetricEigen, SymmetricEigenError,
+    AddDiagonalVectorInPlace, DenseMatrixFromFn, GramMatrix, LinearSolveError,
+    LinearSolveLstsq, LinearSolveSpd, MatTransposeVec, MatVec,
+    MatrixFromDiagonal, MatrixIdentity, MaxDiagonal, SymmetricEigen,
+    SymmetricEigenError,
 };
 pub use sample::{SampleStandardNormal, SampleUniformBox};
 
-// Per-solver plumbing ops: expressed as traits for backend portability, but
-// they carry no meaning outside one shipped solver's internals (diagonal
-// pokes, rank-one updates, the Coleman-Li affine scaling). Kept `pub(crate)`
-// so they stay off the frozen public surface; promote to `pub` on a concrete
-// external request (promotion is non-breaking; the reverse is not).
+// Remaining per-solver plumbing: rank-one updates and Coleman-Li affine
+// scaling stay `pub(crate)`. `AddDiagonalVectorInPlace` and `MaxDiagonal`
+// were promoted to `pub` so out-of-tree `Trf` Jacobian types can implement
+// the damped Gram path (non-breaking; the reverse is not).
 pub(crate) use cl_scaling::BoxAffineScaling;
-pub(crate) use linalg::{
-    AddDiagonalVectorInPlace, GeneralRankOneUpdate, MatDiagonal, MaxDiagonal,
-    RankOneUpdate,
-};
+pub(crate) use linalg::{GeneralRankOneUpdate, MatDiagonal, RankOneUpdate};

--- a/crates/basin/src/lib.rs
+++ b/crates/basin/src/lib.rs
@@ -210,28 +210,28 @@ pub use crate::core::constraint::{
     LinearInequalityConstraints, NonlinearInequalityConstraints,
 };
 pub use crate::core::executor::{
-    Executor, OptimizationResult, StepOutcome, Stepper, run_loop,
+    run_loop, Executor, OptimizationResult, StepOutcome, Stepper,
 };
 pub use crate::core::inner::{
     InitialState, InnerExecutor, ResumableInner, WarmStart,
 };
 pub use crate::core::math::{
-    ClampInPlace, ComponentMulAssign, DenseMatrix, DenseMatrixFromFn, Dot,
-    GramMatrix, LinearSolveError, LinearSolveLstsq, LinearSolveSpd,
-    MatTransposeVec, MatVec, MatrixFromDiagonal, MatrixIdentity, NegInPlace,
-    NormInfinity, NormSquared, SampleStandardNormal, SampleUniformBox, Scalar,
-    ScaleInPlace, ScaledAdd, SymmetricEigen, SymmetricEigenError, VectorIndex,
-    VectorLen,
+    AddDiagonalVectorInPlace, ClampInPlace, ComponentMulAssign, DenseMatrix,
+    DenseMatrixFromFn, Dot, GramMatrix, LinearSolveError, LinearSolveLstsq,
+    LinearSolveSpd, MatTransposeVec, MatVec, MatrixFromDiagonal,
+    MatrixIdentity, MaxDiagonal, NegInPlace, NormInfinity, NormSquared,
+    SampleStandardNormal, SampleUniformBox, Scalar, ScaleInPlace, ScaledAdd,
+    SymmetricEigen, SymmetricEigenError, VectorIndex, VectorLen,
 };
 pub use crate::core::numdiff::{
-    FiniteDiff, Method, central_difference_gradient,
-    central_difference_hessian, central_difference_hessian_product,
-    central_difference_jacobian, forward_difference_gradient,
-    forward_difference_hessian, forward_difference_hessian_product,
-    forward_difference_jacobian,
+    central_difference_gradient, central_difference_hessian,
+    central_difference_hessian_product, central_difference_jacobian,
+    forward_difference_gradient, forward_difference_hessian,
+    forward_difference_hessian_product, forward_difference_jacobian,
+    FiniteDiff, Method,
 };
 #[cfg(all(feature = "serde", not(target_arch = "wasm32")))]
-pub use crate::core::observer::{CheckpointWriter, read_checkpoint};
+pub use crate::core::observer::{read_checkpoint, CheckpointWriter};
 pub use crate::core::observer::{History, Observe, ObserverMode, Report};
 pub use crate::core::problem::{
     CostFunction, EvalCounts, Gradient, Hessian, HessianProduct, Jacobian,
@@ -262,12 +262,12 @@ pub use crate::core::termination::{
 pub use crate::line_search::{
     Backtracking, Constant, LineSearch, MoreThuente, Wolfe,
 };
-pub use crate::solver::Bfgs;
 pub use crate::solver::lbfgs::{Lbfgs, Lbfgsb};
 pub use crate::solver::trust_region::{
     CauchyPoint, Dogleg, ExactHessian, MatrixFree, MoreSorensen, Steihaug,
     TrustRegion,
 };
+pub use crate::solver::Bfgs;
 pub use crate::solver::{
     AcceptanceTest, AugmentedLagrangianMethod, BarrierMethod, BasinHopping,
     Bobyqa, BoundedCmaEs, BoundedCmaInject, Brent, BrentDerivative,


### PR DESCRIPTION
## Summary
- Re-export `AddDiagonalVectorInPlace` and `MaxDiagonal` from the crate root.
- Needed so an out-of-tree Jacobian type can satisfy `Trf`'s damped Gram bounds (`gram` → `add_diagonal_vector_in_place` → `max_diagonal` / `solve_spd`).
- Matches the existing comment on these traits: promote to `pub` on a concrete external request (non-breaking).

Forked at `v1.7.0` as [`jmalicki/basin`](https://github.com/jmalicki/basin/tree/feat/pub-trf-damping-traits) for [vic3-analyzer](https://github.com/jmalicki/vic3-analyzer) joint NLS (structured arrowhead SPD).

## Test plan
- [ ] `cargo test -p basin --features faer`
- [ ] Confirm `AddDiagonalVectorInPlace` and `MaxDiagonal` appear on docs.rs / `basin::`