### PR TITLE
feat: export TRF damping traits

### DIFF
--- a/crates/basin/src/core/math.rs
+++ b/crates/basin/src/core/math.rs
@@ -19,11 +19,12 @@
 //!   a second exception: [`DenseMatrix`] implements it via a pure-Rust
 //!   cyclic Jacobi eigensolver (`dense_eig`), so CMA-ES runs on the default
 //!   backend too. The SPD solve [`LinearSolveSpd`] and its companion
-//!   [`GramMatrix`] (plus the `pub(crate)` `AddDiagonalVectorInPlace`) are a
-//!   third: [`DenseMatrix`] implements them via a pure-Rust Cholesky
-//!   (`dense_chol`), so Gauss-Newton and Levenberg-Marquardt run on the
-//!   default backend. The QR least-squares solve [`LinearSolveLstsq`] (and the
-//!   trust-region-reflective `MaxDiagonal`) stay nalgebra- and faer-only.
+//!   [`GramMatrix`] (plus [`AddDiagonalVectorInPlace`]) are a third:
+//!   [`DenseMatrix`] implements them via a pure-Rust Cholesky (`dense_chol`),
+//!   so Gauss-Newton, Levenberg-Marquardt, and TRF run on the default backend.
+//!   [`AddDiagonalVectorInPlace`] and [`MaxDiagonal`] are public so downstream
+//!   Jacobian types can implement TRF's damping path. The QR least-squares
+//!   solve [`LinearSolveLstsq`] remains backend-specific.
 
 /// Scalar element type for vectors and matrices in the math layer.
 ///
@@ -250,19 +251,14 @@ mod faer_sparse_backend;
 pub use clamp::ClampInPlace;
 pub use dense::DenseMatrix;
 pub use linalg::{
-    DenseMatrixFromFn, GramMatrix, LinearSolveError, LinearSolveLstsq,
-    LinearSolveSpd, MatTransposeVec, MatVec, MatrixFromDiagonal,
-    MatrixIdentity, SymmetricEigen, SymmetricEigenError,
+    AddDiagonalVectorInPlace, DenseMatrixFromFn, GramMatrix, LinearSolveError,
+    LinearSolveLstsq, LinearSolveSpd, MatTransposeVec, MatVec,
+    MatrixFromDiagonal, MatrixIdentity, MaxDiagonal, SymmetricEigen,
+    SymmetricEigenError,
 };
 pub use sample::{SampleStandardNormal, SampleUniformBox};
 
-// Per-solver plumbing ops: expressed as traits for backend portability, but
-// they carry no meaning outside one shipped solver's internals (diagonal
-// pokes, rank-one updates, the Coleman-Li affine scaling). Kept `pub(crate)`
-// so they stay off the frozen public surface; promote to `pub` on a concrete
-// external request (promotion is non-breaking; the reverse is not).
+// Remaining per-solver plumbing ops carry no meaning outside one shipped
+// solver's internals, so they stay off the frozen public surface.
 pub(crate) use cl_scaling::BoxAffineScaling;
-pub(crate) use linalg::{
-    AddDiagonalVectorInPlace, GeneralRankOneUpdate, MatDiagonal, MaxDiagonal,
-    RankOneUpdate,
-};
+pub(crate) use linalg::{GeneralRankOneUpdate, MatDiagonal, RankOneUpdate};

--- a/crates/basin/src/core/math/linalg.rs
+++ b/crates/basin/src/core/math/linalg.rs
@@ -176,8 +176,9 @@ pub trait LinearSolveLstsq<V> {
 }
 
 /// `max_i Aᵢᵢ`, the maximum diagonal entry of a square matrix.
-/// Used by Levenberg-Marquardt to size the initial damping parameter
-/// `μ₀ = τ · max diag(J(x₀)ᵀ J(x₀))` (Nielsen 1999 eq. 1.10).
+/// [`Trf`](crate::Trf) uses it to size the initial damping parameter after
+/// applying the Coleman-Li diagonal correction:
+/// `μ₀ = τ · max diag(J(x₀)ᵀ J(x₀) + diag(c))`.
 ///
 /// # Contract
 ///
@@ -185,19 +186,16 @@ pub trait LinearSolveLstsq<V> {
 /// - **Caller must (sparse precondition):** for sparse impls, missing
 ///   diagonal entries from the CSC pattern are treated as the implicit
 ///   zero. The Gram of any `A` with no zero columns has all-positive
-///   diagonal entries, so the relevant case for LM is unaffected.
-/// - **Implementor must:** return `maxᵢ self[(i, i)]` as `f64`. For an
-///   empty matrix (0×0) the result is unspecified; backends may return
-///   `0.0` or `f64::NEG_INFINITY`. Callers should not invoke on empty
-///   matrices.
+///   diagonal entries, so TRF's damping path is unaffected.
+/// - **Implementor must:** return `maxᵢ self[(i, i)]` as `F`. For an empty
+///   matrix (0×0), the result is unspecified; callers should not invoke
+///   this method on empty matrices.
 ///
 /// # Backends
 ///
-/// Same coverage as [`AddDiagonalInPlace`].
+/// Same coverage as [`AddDiagonalVectorInPlace`].
 ///
-/// The `F` parameter is the scalar; it defaults to `f64`, which is the only
-/// scalar every backend currently implements. Future f32/extended-precision
-/// impls would specify it explicitly.
+/// The `F` parameter is the scalar and defaults to `f64`.
 pub trait MaxDiagonal<F = f64> {
     /// Compute the maximum diagonal entry as `F`.
     fn max_diagonal(&self) -> F;

--- a/crates/basin/src/lib.rs
+++ b/crates/basin/src/lib.rs
@@ -216,12 +216,12 @@ pub use crate::core::inner::{
     InitialState, InnerExecutor, ResumableInner, WarmStart,
 };
 pub use crate::core::math::{
-    ClampInPlace, ComponentMulAssign, DenseMatrix, DenseMatrixFromFn, Dot,
-    GramMatrix, LinearSolveError, LinearSolveLstsq, LinearSolveSpd,
-    MatTransposeVec, MatVec, MatrixFromDiagonal, MatrixIdentity, NegInPlace,
-    NormInfinity, NormSquared, SampleStandardNormal, SampleUniformBox, Scalar,
-    ScaleInPlace, ScaledAdd, SymmetricEigen, SymmetricEigenError, VectorIndex,
-    VectorLen,
+    AddDiagonalVectorInPlace, ClampInPlace, ComponentMulAssign, DenseMatrix,
+    DenseMatrixFromFn, Dot, GramMatrix, LinearSolveError, LinearSolveLstsq,
+    LinearSolveSpd, MatTransposeVec, MatVec, MatrixFromDiagonal,
+    MatrixIdentity, MaxDiagonal, NegInPlace, NormInfinity, NormSquared,
+    SampleStandardNormal, SampleUniformBox, Scalar, ScaleInPlace, ScaledAdd,
+    SymmetricEigen, SymmetricEigenError, VectorIndex, VectorLen,
 };
 pub use crate::core::numdiff::{
     FiniteDiff, Method, central_difference_gradient,

--- a/crates/basin/tests/trf_custom_jacobian.rs
+++ b/crates/basin/tests/trf_custom_jacobian.rs
@@ -1,0 +1,109 @@
+use std::convert::Infallible;
+
+use basin::{
+    AddDiagonalVectorInPlace, BoxConstraints, CostFunction, Executor,
+    GramMatrix, Jacobian, LinearSolveError, LinearSolveSpd, MatTransposeVec,
+    MaxDiagonal, Residual, TerminationReason, Trf,
+};
+
+#[derive(Clone)]
+struct ScalarMatrix(f64);
+
+impl GramMatrix for ScalarMatrix {
+    fn gram(&self) -> Self {
+        Self(self.0 * self.0)
+    }
+}
+
+impl MatTransposeVec<Vec<f64>> for ScalarMatrix {
+    fn mat_transpose_vec(&self, x: &Vec<f64>) -> Vec<f64> {
+        assert_eq!(x.len(), 1);
+        vec![self.0 * x[0]]
+    }
+}
+
+impl LinearSolveSpd<Vec<f64>> for ScalarMatrix {
+    fn solve_spd(&self, b: &Vec<f64>) -> Result<Vec<f64>, LinearSolveError> {
+        assert_eq!(b.len(), 1);
+        if self.0 <= 0.0 {
+            return Err(LinearSolveError::NotPositiveDefinite);
+        }
+        Ok(vec![b[0] / self.0])
+    }
+}
+
+impl AddDiagonalVectorInPlace<Vec<f64>> for ScalarMatrix {
+    fn add_diagonal_vector_in_place(&mut self, diagonal: &Vec<f64>) {
+        assert_eq!(diagonal.len(), 1);
+        self.0 += diagonal[0];
+    }
+}
+
+impl MaxDiagonal for ScalarMatrix {
+    fn max_diagonal(&self) -> f64 {
+        self.0
+    }
+}
+
+struct BoundedResidual {
+    lower: Vec<f64>,
+    upper: Vec<f64>,
+}
+
+impl CostFunction for BoundedResidual {
+    type Param = Vec<f64>;
+    type Output = f64;
+    type Error = Infallible;
+
+    fn cost(&self, x: &Vec<f64>) -> Result<f64, Self::Error> {
+        Ok(0.5 * (x[0] - 2.0).powi(2))
+    }
+}
+
+impl Residual for BoundedResidual {
+    type Param = Vec<f64>;
+    type Output = Vec<f64>;
+    type Error = Infallible;
+
+    fn residual(&self, x: &Vec<f64>) -> Result<Vec<f64>, Self::Error> {
+        Ok(vec![x[0] - 2.0])
+    }
+}
+
+impl Jacobian for BoundedResidual {
+    type Jacobian = ScalarMatrix;
+
+    fn jacobian(&self, _x: &Vec<f64>) -> Result<ScalarMatrix, Self::Error> {
+        Ok(ScalarMatrix(1.0))
+    }
+}
+
+impl BoxConstraints for BoundedResidual {
+    fn lower(&self) -> &Vec<f64> {
+        &self.lower
+    }
+
+    fn upper(&self) -> &Vec<f64> {
+        &self.upper
+    }
+}
+
+#[test]
+fn trf_accepts_a_downstream_jacobian_type() {
+    let problem = BoundedResidual {
+        lower: vec![-10.0],
+        upper: vec![10.0],
+    };
+
+    let result = Executor::from_start(
+        problem,
+        Trf::<Vec<f64>, ScalarMatrix>::new(),
+        vec![0.0],
+    )
+    .max_iter(50)
+    .run()
+    .unwrap();
+
+    assert_eq!(result.reason, TerminationReason::SolverConverged);
+    assert!((result.param()[0] - 2.0).abs() < 1e-8);
+}


### PR DESCRIPTION
## Summary

- Re-export `AddDiagonalVectorInPlace` and `MaxDiagonal` through `core::math` and the crate root.
- Repair the newly public `MaxDiagonal` contract and backend documentation.
- Add an integration test proving a downstream-defined Jacobian can implement the required capabilities and run with `Trf`.

This follows up on #84 and credits Joseph Malicki as a co-author.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p basin --features nalgebra,ndarray,faer,problems,parallel`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo doc --no-deps -p basin --all-features`