### PR TITLE
feat: support versioned linear algebra backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,26 @@ jobs:
       - name: Install clippy
         run: rustup component add clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-features --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-features --all-targets -- -D warnings
+
+  msrv:
+    name: MSRV (Rust 1.87)
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.87.0
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.87.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+      # nalgebra 0.35 requires Rust 1.89. Every backend version and
+      # acceleration feature below that boundary must still compile at Basin's
+      # package MSRV, including tests, examples, and benchmarks.
+      - run: >-
+          cargo check -p basin --all-targets --no-default-features
+          --features
+          nalgebra_v0_32-lapack,nalgebra_v0_33-lapack,nalgebra_v0_34-lapack,ndarray_v0_15-blas,ndarray_v0_16-blas,ndarray_v0_17-blas,faer_v0_22,faer_v0_23,faer_v0_24,parallel,problems,serde
 
   docs:
     name: rustdoc
@@ -36,15 +55,17 @@ jobs:
     env:
       # rustdoc lints (broken links, redundant targets, missing docs, ...)
       # are warnings by default; -D promotes them to hard errors so docs
-      # can't rot. Built with --all-features to exercise the feature-gated
-      # backend impls, mirroring the docs.rs config.
+      # can't rot. Build the latest backend aliases, mirroring the docs.rs
+      # config without documenting every parallel version of each backend.
       RUSTDOCFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v7
       - uses: Swatinem/rust-cache@v2
         with:
           key: docs
-      - run: cargo doc --no-deps -p basin --all-features
+      - run: >-
+          cargo doc --no-deps -p basin
+          --features nalgebra_latest-lapack,ndarray_latest-blas,faer_latest,parallel,problems,serde
 
   test:
     name: test (${{ matrix.features }})
@@ -55,17 +76,33 @@ jobs:
         include:
           - features: default
             flags: ""
-          - features: nalgebra
-            flags: "--features nalgebra"
-          - features: ndarray
-            flags: "--features ndarray"
-          - features: faer
-            flags: "--features faer"
+          - features: nalgebra 0.32
+            flags: "--no-default-features --features nalgebra_v0_32,problems"
+          - features: nalgebra 0.33
+            flags: "--no-default-features --features nalgebra_v0_33,problems"
+          - features: nalgebra 0.34
+            flags: "--no-default-features --features nalgebra_v0_34,problems"
+          - features: nalgebra 0.35
+            flags: "--no-default-features --features nalgebra_v0_35,problems"
+          - features: ndarray 0.15
+            flags: "--no-default-features --features ndarray_v0_15,problems"
+          - features: ndarray 0.16
+            flags: "--no-default-features --features ndarray_v0_16,problems"
+          - features: ndarray 0.17
+            flags: "--no-default-features --features ndarray_v0_17,problems"
+          - features: faer 0.22
+            flags: "--no-default-features --features faer_v0_22,problems"
+          - features: faer 0.23
+            flags: "--no-default-features --features faer_v0_23,problems"
+          - features: faer 0.24
+            flags: "--no-default-features --features faer_v0_24,problems"
+          # Preserve the pre-versioning feature meanings in Basin 1.x.
+          - features: legacy aliases
+            flags: "--features nalgebra,ndarray,faer"
           # Exercise the rayon-backed `parallel` path (FiniteDiff probe
-          # fan-out). Matrix backends are needed for the FD Jacobian/Hessian
-          # tests; faer + nalgebra cover both.
-          - features: parallel
-            flags: "--features nalgebra,faer,parallel"
+          # fan-out) and the moving aliases together.
+          - features: latest aliases + parallel
+            flags: "--features nalgebra_latest,ndarray_latest,faer_latest,parallel"
     steps:
       - uses: actions/checkout@v7
       - uses: Swatinem/rust-cache@v2
@@ -74,15 +111,22 @@ jobs:
       - run: cargo build -p basin ${{ matrix.flags }}
       - run: cargo test -p basin ${{ matrix.flags }}
 
-  # `nalgebra-lapack` is the one feature that links a system LAPACK, so it gets
-  # its own job rather than a matrix row (and is absent from the wasm matrix —
-  # it must never build for wasm). The feature forwards `lapack-custom`, so the
-  # LAPACK symbols are supplied here at link time by Ubuntu's LP64 OpenBLAS
-  # (`libopenblas-dev`). The integer width matters: the LP64 build (32-bit int)
-  # matches `lapack-sys`; the ILP64 build segfaults at runtime.
+  # The versioned nalgebra LAPACK features link a system LAPACK, so they get a
+  # separate matrix (and remain absent from the wasm matrix). LAPACK symbols
+  # are supplied at link time by Ubuntu's LP64 OpenBLAS (`libopenblas-dev`).
+  # The integer width matters: the LP64 build (32-bit int) matches
+  # `lapack-sys`; the ILP64 build segfaults at runtime.
   lapack:
-    name: test (nalgebra-lapack)
+    name: test (${{ matrix.feature }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - nalgebra_v0_32-lapack
+          - nalgebra_v0_33-lapack
+          - nalgebra_v0_34-lapack
+          - nalgebra_v0_35-lapack
     env:
       # Override the workflow-level RUSTFLAGS (job env replaces, not merges), so
       # keep `-D warnings` and append the OpenBLAS link directive.
@@ -93,8 +137,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev
       - uses: Swatinem/rust-cache@v2
         with:
-          key: nalgebra-lapack
-      - run: cargo test -p basin --features nalgebra-lapack --test lapack_nalgebra
+          key: ${{ matrix.feature }}
+      - run: cargo test -p basin --features ${{ matrix.feature }} --test lapack_nalgebra
 
   wasm:
     name: wasm build (${{ matrix.features }})
@@ -107,6 +151,8 @@ jobs:
             flags: ""
           - features: nalgebra
             flags: "--features nalgebra"
+          - features: nalgebra latest
+            flags: "--features nalgebra_latest"
           - features: ndarray
             flags: "--features ndarray"
           - features: faer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,12 @@ and faer backends.
 - Preserve the default `wasm32-unknown-unknown` build. Gate file I/O, threads,
   rayon, and BLAS/LAPACK-linked math behind non-default features. Use `web-time`
   rather than `std::time::Instant` in default paths.
-- Do not bump the Rust version casually. Check the current CRAN toolchain before
-  changing `rust-version`, `rust-toolchain.toml`, or the dev pin. Every dependency,
-  including dev dependencies used during publishing and CI, must compile on the
-  MSRV. Document the reason beside any MSRV-driven pin.
+- Do not bump the package MSRV casually. Check the current CRAN toolchain before
+  changing `rust-version`. The development toolchain may be newer when a
+  versioned opt-in backend requires it. Every dependency selected by the
+  MSRV-compatible features, including dev dependencies used during publishing
+  and CI, must compile on the MSRV. Document the reason beside any MSRV-driven
+  pin or feature-specific exception.
 
 ## Verification
 
@@ -29,9 +31,10 @@ Run focused tests while developing, then the checks matching the changed scope:
 
 - Rust formatting: `cargo fmt --all -- --check`.
 - Routine pure-Rust tests:
-  `cargo test -p basin --features nalgebra,ndarray,faer,problems,parallel`.
+  `cargo test -p basin --features nalgebra_latest,ndarray_latest,faer_latest,problems,parallel`.
 - Workspace lint: `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
-- Public documentation: `cargo doc --no-deps -p basin --all-features`.
+- Public documentation:
+  `cargo doc --no-deps -p basin --features nalgebra_latest-lapack,ndarray_latest-blas,faer_latest,parallel,problems,serde`.
 - WASM-sensitive changes:
   `cargo build --target wasm32-unknown-unknown` and
   `cargo build --target wasm32-unknown-unknown --no-default-features`.
@@ -41,9 +44,10 @@ Run focused tests while developing, then the checks matching the changed scope:
 Do not assume `cargo test --all-features` links without a BLAS/LAPACK provider.
 The `nalgebra-lapack` and `ndarray-blas` features intentionally select no
 provider. Supply one through linker flags when those tests are required; clippy
-and rustdoc with all features only check and do not link. The dev environment
-pins Rust 1.87.0, supplies the WASM target and project tooling, and runs
-all-feature clippy and rustfmt in pre-commit.
+and rustdoc only check and do not link. The package MSRV is Rust 1.87.0; CI
+checks it separately. The dev environment pins Rust 1.89.0, supplies the WASM
+target and project tooling, and runs all-feature clippy and rustfmt in
+pre-commit.
 
 ## Architecture and repository shape
 
@@ -78,8 +82,11 @@ belong in the core crate.
 
 1. Preserve conventional optimization-framework vocabulary and the generic
    driver-loop shape unless another constraint requires divergence.
-2. Each backend has one Cargo feature pinned to one major version. A backend
-   major bump is a Basin major bump; do not add per-version feature gates.
+2. Each supported backend release has an exact version feature. The
+   `*_latest` aliases move to the newest supported release, while the original
+   unversioned features retain their Basin 1.x meanings. If dependency feature
+   unification enables several releases of one backend, implement the newest
+   enabled release.
 3. Generic stopping criteria belong to the executor/shared termination layer;
    solver-specific controls stay on the solver. Bind each criterion to the
    minimum state shape it needs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,9 @@ backend (`Vec<f64>`, nalgebra, ndarray, faer).
 - `cargo test`: run tests.
 - `cargo test <name>`: run a single test by name.
 - `cargo clippy --workspace --all-targets --all-features -- -D warnings`: lint.
-- `cargo doc --no-deps -p basin --all-features`: build the docs. CI runs this
-  and `lib.rs` has `#![deny(rustdoc::broken_intra_doc_links)]`, so a broken or
+- `cargo doc --no-deps -p basin --features nalgebra_latest-lapack,ndarray_latest-blas,faer_latest,parallel,problems,serde`:
+  build the public docs with the latest backend versions. CI runs this, and
+  `lib.rs` has `#![deny(rustdoc::broken_intra_doc_links)]`, so a broken or
   ambiguous intra-doc link (e.g. `[`Foo`](super::foo)` where `foo` is both a
   module and a function; link the struct `super::Foo` instead) fails the build.
   Run this before committing any rustdoc changes.
@@ -38,12 +39,11 @@ backend (`Vec<f64>`, nalgebra, ndarray, faer).
 
 ### `cargo test --all-features` needs a BLAS/LAPACK provider
 
-`cargo clippy --all-features` and `cargo doc --all-features` work out of the box
-because they only *check* and never *link*. `cargo test --all-features` is
-different: it links executables, and the `nalgebra-lapack`/`ndarray-blas`
-features deliberately pull in **no** BLAS/LAPACK provider crate (see the
-`Cargo.toml` comments: `nalgebra-lapack` forwards `lapack-custom` precisely so
-the rlib/docs build without a Fortran toolchain). So a bare
+`cargo clippy --all-features` and `cargo doc` with acceleration features work
+out of the box because they only *check* and never *link*.
+`cargo test --all-features` is different: it links executables, and the
+versioned nalgebra LAPACK and ndarray BLAS features deliberately pull in
+**no** BLAS/LAPACK provider crate. So a bare
 `cargo test --all-features` fails at link time with
 `undefined reference to dsyev_`/`dpotrf_`—this is by design, not a missing
 system library. Installing `liblapack`/`libblas` is not enough on its own;
@@ -60,16 +60,17 @@ RUSTFLAGS="-L $OB -l openblas" cargo test -p basin --all-features
 
 Outside Nix, an `-L <dir> -l openblas` (or `-l lapack -l blas` for reference
 netlib) pointing at your system libraries does the same. CI does **not** run
-`--all-features` *tests*; the routine local test command is the pure-Rust
-feature set:
-`cargo test -p basin --features nalgebra,ndarray,faer,problems,parallel`.
+`--all-features` *tests*; the routine local test command is the latest
+pure-Rust feature set:
+`cargo test -p basin --features nalgebra_latest,ndarray_latest,faer_latest,problems,parallel`.
 
 The dev environment is provided by `devenv.nix` (loaded automatically via
-`direnv` from `.envrc`). It pins Rust 1.87.0 (matches `rust-version` in
-`Cargo.toml`) and adds the `wasm32-unknown-unknown` target plus tooling:
+`direnv` from `.envrc`). It pins Rust 1.89.0 and adds the
+`wasm32-unknown-unknown` target plus tooling:
 `cargo-llvm-cov`, `cargo-flamegraph`, `cargo-audit`, `cargo-deny`, `cargo-msrv`,
 `samply`, `wasm-pack`, `go-task`. Pre-commit hooks run `clippy` (with
-`allFeatures = true`) and `rustfmt`.
+`allFeatures = true`) and `rustfmt`. Basin's package MSRV remains Rust 1.87.0;
+the dedicated CI job checks every feature compatible with that toolchain.
 
 ## Architecture
 
@@ -122,11 +123,12 @@ These shape API decisions and are non-obvious from the code alone.
    `IterState`-style `State`) and a generic driver-loop architecture. Familiar
    names lower the barrier for users arriving from existing frameworks; diverge
    only when another tenet demands it.
-2. **One feature per backend, one pinned version.** Each linear-algebra backend
-   (`nalgebra`, `ndarray`, `faer`) is a single Cargo feature pinning one major
-   version; `Vec<f64>` needs none. A backend major bump is a basin major bump.
-   No per-version feature gates (`nalgebra-v0_33`/`-v0_34`): they multiply the
-   test matrix and maintenance surface for little gain.
+2. **Versioned backend compatibility.** Each supported nalgebra, ndarray, and
+   faer release has an exact Cargo feature; `Vec<f64>` needs none. Moving
+   `*_latest` aliases select the newest supported releases, while the original
+   unversioned aliases retain their Basin 1.x meanings. Cargo features are
+   additive, so the implementation selects the newest enabled release when
+   dependency feature unification enables several versions of one backend.
 3. **Framework-level termination.** Generic stopping conditions (`max_iter`, the
    `*_tolerance` family, `max_time`, eval budgets) are configured uniformly on
    the `Executor`/shared termination layer, not per solver; solver-specific
@@ -171,20 +173,22 @@ dependencies, not a feature. CI enforces it
 
 ## MSRV is externally constrained: do not bump casually
 
-Basin's MSRV (pinned in `rust-toolchain.toml`) is set by downstream consumers,
-not basin's own preferences:
+Basin's package MSRV (declared as `rust-version` in `Cargo.toml`) is set by
+downstream consumers, not Basin's own preferences. The development toolchain
+is newer so it can exercise every supported backend:
 
 - **Primary: CRAN.** A planned R-package wrapper must build under CRAN's Rust
   toolchain, which lags stable significantly. Bumping above CRAN's pin makes the
-  R bindings unshippable. Don't bump `rust-version`/the `devenv.nix` pin without
-  checking the current CRAN toolchain first.
+  R bindings unshippable. Do not bump `rust-version` without checking the
+  current CRAN toolchain first.
 - **Secondary (non-binding): Python bindings**: PyO3 and maturin track recent
   stable, so unlikely to bind tighter than CRAN.
-- Every new dep (and dev-dep, which is exercised by `cargo publish --dry-run`
-  and CI) must compile under the MSRV. Prefer small, stable transitive trees
-  over feature-rich ones with sprawling graphs. When MSRV pain forces a pin,
-  document the *reason* in `Cargo.toml` next to it so future-you doesn't lift it
-  without re-checking CRAN.
+- Every new dependency selected by an MSRV-compatible feature, including dev
+  dependencies exercised by `cargo publish --dry-run` and CI, must compile
+  under the MSRV. A feature may require a newer compiler when an explicitly
+  supported dependency release does; document that exception beside the
+  dependency and test the remaining feature set in the MSRV CI job. Prefer
+  small, stable transitive trees over feature-rich ones with sprawling graphs.
 
 ## Repo structure: workspace
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,13 +100,28 @@ version = "1.7.0"
 dependencies = [
  "bincode",
  "criterion",
- "faer",
- "faer-traits",
+ "faer 0.22.6",
+ "faer 0.23.2",
+ "faer 0.24.4",
+ "faer-traits 0.22.1",
+ "faer-traits 0.23.2",
+ "faer-traits 0.24.0",
  "generativity",
+ "nalgebra 0.32.6",
+ "nalgebra 0.33.3",
  "nalgebra 0.34.2",
- "nalgebra-lapack",
- "nalgebra-sparse",
- "ndarray",
+ "nalgebra 0.35.0",
+ "nalgebra-lapack 0.24.0",
+ "nalgebra-lapack 0.25.0",
+ "nalgebra-lapack 0.27.0",
+ "nalgebra-lapack 0.28.0",
+ "nalgebra-sparse 0.10.0",
+ "nalgebra-sparse 0.11.0",
+ "nalgebra-sparse 0.12.0",
+ "nalgebra-sparse 0.9.0",
+ "ndarray 0.15.6",
+ "ndarray 0.16.1",
+ "ndarray 0.17.2",
  "num-traits",
  "rand 0.10.2",
  "rand_chacha 0.10.0",
@@ -305,10 +320,11 @@ dependencies = [
  "argmin-math",
  "basin",
  "criterion",
- "faer",
+ "faer 0.24.4",
  "gomez",
  "levenberg-marquardt",
  "nalgebra 0.34.2",
+ "nalgebra 0.35.0",
  "nlopt",
  "rayon",
 ]
@@ -515,6 +531,53 @@ checksum = "2b14b339eb76d07f052cdbad76ca7c1310e56173a138095d3bf42a23c06ef5d8"
 
 [[package]]
 name = "faer"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fce40ad65c366fbc6cd70a99d09d1008f075280bf2455e558e163c82913a9f"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "equator 0.4.2",
+ "faer-macros 0.21.0",
+ "faer-traits 0.22.1",
+ "gemm 0.18.2",
+ "generativity",
+ "libm",
+ "nano-gemm 0.1.3",
+ "num-complex",
+ "num-traits",
+ "private-gemm-x86",
+ "pulp 0.21.5",
+ "rayon",
+ "reborrow",
+]
+
+[[package]]
+name = "faer"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb922206162d9405f9fc059052b3f997bdc92745da7bfd620645f5092df20d1"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "equator 0.4.2",
+ "faer-macros 0.22.1",
+ "faer-traits 0.23.2",
+ "gemm 0.18.2",
+ "generativity",
+ "libm",
+ "nano-gemm 0.1.3",
+ "num-complex",
+ "num-traits",
+ "private-gemm-x86",
+ "pulp 0.21.5",
+ "rayon",
+ "reborrow",
+ "spindle",
+]
+
+[[package]]
+name = "faer"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab6df3dd147fe8d702a288b95bcd8fcc499ab572fc80da6828f60cd4d524d67"
@@ -522,18 +585,76 @@ dependencies = [
  "bytemuck",
  "dyn-stack",
  "equator 0.6.0",
- "faer-traits",
- "gemm",
+ "faer-traits 0.24.0",
+ "gemm 0.19.0",
  "generativity",
  "libm",
- "nano-gemm",
+ "nano-gemm 0.2.2",
  "num-complex",
  "num-traits",
  "private-gemm-x86",
- "pulp",
+ "pulp 0.22.3",
  "rayon",
  "reborrow",
  "spindle",
+]
+
+[[package]]
+name = "faer-macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d0a255d1442b5825c61812a7eafda9034ec53d969c98555251085e148428e6a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "faer-macros"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cc4b8cd876795d3b19ddfd59b03faa303c0b8adb9af6e188e81fc647c485bb9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "faer-traits"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54febfcbb90edaab562d85447a94d500f1601f11db0b30d27da87ed6542c8f91"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "faer-macros 0.21.0",
+ "generativity",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp 0.21.5",
+ "qd 0.7.7",
+ "reborrow",
+]
+
+[[package]]
+name = "faer-traits"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b69235b5f54416286c485fb047f2f499fc935a4eee2caadf4757f3c94c7b62"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "faer-macros 0.22.1",
+ "generativity",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp 0.21.5",
+ "qd 0.7.7",
+ "reborrow",
 ]
 
 [[package]]
@@ -548,8 +669,8 @@ dependencies = [
  "libm",
  "num-complex",
  "num-traits",
- "pulp",
- "qd",
+ "pulp 0.22.3",
+ "qd 0.8.0",
  "reborrow",
 ]
 
@@ -600,17 +721,52 @@ dependencies = [
 
 [[package]]
 name = "gemm"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32 0.18.2",
+ "gemm-c64 0.18.2",
+ "gemm-common 0.18.2",
+ "gemm-f16 0.18.2",
+ "gemm-f32 0.18.2",
+ "gemm-f64 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
 dependencies = [
  "dyn-stack",
- "gemm-c32",
- "gemm-c64",
- "gemm-common",
- "gemm-f16",
- "gemm-f32",
- "gemm-f64",
+ "gemm-c32 0.19.0",
+ "gemm-c64 0.19.0",
+ "gemm-common 0.19.0",
+ "gemm-f16 0.19.0",
+ "gemm-f32 0.19.0",
+ "gemm-f64 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
  "num-complex",
  "num-traits",
  "paste",
@@ -625,7 +781,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
 dependencies = [
  "dyn-stack",
- "gemm-common",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
  "num-complex",
  "num-traits",
  "paste",
@@ -640,12 +811,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
 dependencies = [
  "dyn-stack",
- "gemm-common",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
  "raw-cpuid",
  "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.21.5",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
+ "sysctl",
 ]
 
 [[package]]
@@ -662,11 +854,29 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
- "pulp",
+ "pulp 0.22.3",
  "raw-cpuid",
  "rayon",
  "seq-macro",
  "sysctl",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "gemm-f32 0.18.2",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "rayon",
+ "seq-macro",
 ]
 
 [[package]]
@@ -676,8 +886,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
 dependencies = [
  "dyn-stack",
- "gemm-common",
- "gemm-f32",
+ "gemm-common 0.19.0",
+ "gemm-f32 0.19.0",
  "half",
  "num-complex",
  "num-traits",
@@ -689,12 +899,42 @@ dependencies = [
 
 [[package]]
 name = "gemm-f32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
 dependencies = [
  "dyn-stack",
- "gemm-common",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.18.2",
  "num-complex",
  "num-traits",
  "paste",
@@ -709,7 +949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
 dependencies = [
  "dyn-stack",
- "gemm-common",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
@@ -870,6 +1110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 
 [[package]]
+name = "glam"
+version = "0.33.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21fef0953c54fd3de2f44b743fbf77e044c81a25faee03636dfccc0d35135e23"
+
+[[package]]
 name = "gomez"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,13 +1194,39 @@ dependencies = [
 
 [[package]]
 name = "lapack"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad676a6b4df7e76a9fd80a0c50c619a3948d6105b62a0ab135f064d99c51d207"
+dependencies = [
+ "lapack-sys 0.14.0",
+ "libc",
+ "num-complex",
+]
+
+[[package]]
+name = "lapack"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "508f7f48955e5e4ec3feb771a4d981c6e59ff2400d750cf41733a3350fdb2dc4"
 dependencies = [
- "lapack-sys",
+ "lapack-sys 0.15.0",
  "libc",
  "num-complex",
+]
+
+[[package]]
+name = "lapack-src"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3cb33e1ac8989473dde32d37edc8cd0da00b655306eb5bb1cb0b7968612b2"
+
+[[package]]
+name = "lapack-sys"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447f56c85fb410a7a3d36701b2153c1018b1d2b908c5fbaf01c1b04fac33bcbe"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1052,7 +1324,25 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
+ "serde",
  "simba 0.8.1",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros 0.2.2",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "serde",
+ "simba 0.9.1",
  "typenum",
 ]
 
@@ -1092,18 +1382,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
+dependencies = [
+ "approx",
+ "glam 0.30.10",
+ "glam 0.31.1",
+ "glam 0.32.1",
+ "glam 0.33.6",
+ "matrixmultiply",
+ "nalgebra-macros 0.3.0",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "serde",
+ "simba 0.10.2",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-lapack"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a624592c6df3fc0a459312dac2621316730fdb9a7a44178b7a4bd0353b1bb7"
+dependencies = [
+ "lapack 0.19.0",
+ "lapack-src",
+ "nalgebra 0.32.6",
+ "num-complex",
+ "num-traits",
+ "simba 0.8.1",
+]
+
+[[package]]
+name = "nalgebra-lapack"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d1c3c6c8f1eeaeefda3f0e3517af4c294c44f5c2929101f6b0dc977d1db7"
+dependencies = [
+ "lapack 0.19.0",
+ "lapack-src",
+ "nalgebra 0.33.3",
+ "num-complex",
+ "num-traits",
+ "simba 0.9.1",
+]
+
+[[package]]
 name = "nalgebra-lapack"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3fada944cb81d198c5e9f2c04168c7bbade833ec6eefa0b518be92ae9bbb8a"
 dependencies = [
  "blas",
- "lapack",
+ "lapack 0.20.0",
  "nalgebra 0.34.2",
  "num-complex",
  "num-traits",
  "simba 0.9.1",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "nalgebra-lapack"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a883a8a3b00779cd1d9b23adae0f82def9681b0dbf63c05b1e630399250f6d6f"
+dependencies = [
+ "blas",
+ "lapack 0.20.0",
+ "nalgebra 0.35.0",
+ "num-complex",
+ "num-traits",
+ "simba 0.10.2",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1130,6 +1484,26 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-sparse"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b113b3101e137b3d0ef20b76b7579cde88e3d1f2f64993d4d6a49f232055cc9"
+dependencies = [
+ "nalgebra 0.32.6",
+ "num-traits",
+]
+
+[[package]]
+name = "nalgebra-sparse"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1107e2587bc373090389bd5b54e05ac3184fd02d7c102decf5d76b8feb84b2d0"
+dependencies = [
+ "nalgebra 0.33.3",
+ "num-traits",
+]
+
+[[package]]
+name = "nalgebra-sparse"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df054d7815152d4e66955fc59a1f97f4036e5103134a381b6b54ec55babfa6b7"
@@ -1139,18 +1513,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra-sparse"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8935b578b6a012f3667131452add895472f37c242d2844497daf7c49f6b8059"
+dependencies = [
+ "nalgebra 0.35.0",
+ "num-traits",
+]
+
+[[package]]
+name = "nano-gemm"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5ba2bea1c00e53de11f6ab5bd0761ba87dc0045d63b0c87ee471d2d3061376"
+dependencies = [
+ "equator 0.2.2",
+ "nano-gemm-c32 0.1.0",
+ "nano-gemm-c64 0.1.0",
+ "nano-gemm-codegen 0.1.0",
+ "nano-gemm-core 0.1.0",
+ "nano-gemm-f32 0.1.0",
+ "nano-gemm-f64 0.1.0",
+ "num-complex",
+]
+
+[[package]]
 name = "nano-gemm"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e04345dc84b498ff89fe0d38543d1f170da9e43a2c2bcee73a0f9069f72d081"
 dependencies = [
  "equator 0.2.2",
- "nano-gemm-c32",
- "nano-gemm-c64",
- "nano-gemm-codegen",
- "nano-gemm-core",
- "nano-gemm-f32",
- "nano-gemm-f64",
+ "nano-gemm-c32 0.2.1",
+ "nano-gemm-c64 0.2.1",
+ "nano-gemm-codegen 0.2.1",
+ "nano-gemm-core 0.2.1",
+ "nano-gemm-f32 0.2.1",
+ "nano-gemm-f64 0.2.1",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40449e57a5713464c3a1208c4c3301c8d29ee1344711822cf022bc91373a91b"
+dependencies = [
+ "nano-gemm-codegen 0.1.0",
+ "nano-gemm-core 0.1.0",
  "num-complex",
 ]
 
@@ -1160,8 +1571,19 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0775b1e2520e64deee8fc78b7732e3091fb7585017c0b0f9f4b451757bbbc562"
 dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
+ "nano-gemm-codegen 0.2.1",
+ "nano-gemm-core 0.2.1",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c64"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743a6e6211358fba85d1009616751e4107da86f4c95b24e684ce85f25c25b3bf"
+dependencies = [
+ "nano-gemm-codegen 0.1.0",
+ "nano-gemm-core 0.1.0",
  "num-complex",
 ]
 
@@ -1171,10 +1593,16 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9af49a20d58816e6b5ee65f64142e50edb5eba152678d4bb7377fcbf63f8437a"
 dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
+ "nano-gemm-codegen 0.2.1",
+ "nano-gemm-core 0.2.1",
  "num-complex",
 ]
+
+[[package]]
+name = "nano-gemm-codegen"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963bf7c7110d55430169dc74c67096375491ed580cd2ef84842550ac72e781fa"
 
 [[package]]
 name = "nano-gemm-codegen"
@@ -1184,9 +1612,25 @@ checksum = "6cc8d495c791627779477a2cf5df60049f5b165342610eb0d76bee5ff5c5d74c"
 
 [[package]]
 name = "nano-gemm-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3fc4f83ae8861bad79dc3c016bd6b0220da5f9de302e07d3112d16efc24aa6"
+
+[[package]]
+name = "nano-gemm-core"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d998dfa644de87a0f8660e5ea511d7cb5c33b5a2d9847b7af57a2565105089f0"
+
+[[package]]
+name = "nano-gemm-f32"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3681b7ce35658f79da94b7f62c60a005e29c373c7111ed070e3bf64546a8bb"
+dependencies = [
+ "nano-gemm-codegen 0.1.0",
+ "nano-gemm-core 0.1.0",
+]
 
 [[package]]
 name = "nano-gemm-f32"
@@ -1194,8 +1638,18 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d962e79bc8952e4ad21ca4845a21132540ed3f5e01184b2ff7f720e666523"
 dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
+ "nano-gemm-codegen 0.2.1",
+ "nano-gemm-core 0.2.1",
+]
+
+[[package]]
+name = "nano-gemm-f64"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1e619ed04d801809e1f63e61b669d380c4119e8b0cdd6ed184c6b111f046d8"
+dependencies = [
+ "nano-gemm-codegen 0.1.0",
+ "nano-gemm-core 0.1.0",
 ]
 
 [[package]]
@@ -1204,8 +1658,42 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9a513473dce7dc00c7e7c318481ca4494034e76997218d8dad51bd9f007a815"
 dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
+ "nano-gemm-codegen 0.2.1",
+ "nano-gemm-core 0.2.1",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "cblas-sys",
+ "libc",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+ "serde",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "cblas-sys",
+ "libc",
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+ "serde",
 ]
 
 [[package]]
@@ -1390,6 +1878,20 @@ dependencies = [
 
 [[package]]
 name = "pulp"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
@@ -1413,6 +1915,18 @@ checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "qd"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8bb755b6008c3b41bf8a0866c8dd4e1245a2f011ceaa22a13ee55c538493e2"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-traits",
+ "pulp 0.21.5",
+]
+
+[[package]]
+name = "qd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f1304a5aecdcfe9ee72fbba90aa37b3aa067a69d14cb7f3d9deada0be7c07c"
@@ -1420,7 +1934,7 @@ dependencies = [
  "bytemuck",
  "libm",
  "num-traits",
- "pulp",
+ "pulp 0.22.3",
 ]
 
 [[package]]
@@ -1606,6 +2120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe_arch"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,7 +2234,7 @@ dependencies = [
  "num-complex",
  "num-traits",
  "paste",
- "wide",
+ "wide 0.7.33",
 ]
 
 [[package]]
@@ -1724,7 +2247,19 @@ dependencies = [
  "num-complex",
  "num-traits",
  "paste",
- "wide",
+ "wide 0.7.33",
+]
+
+[[package]]
+name = "simba"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a7200d82ff1c7b4235efd12f11e2537a402c91cf83a5cb97ce80eef787fde7"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "wide 1.7.0",
 ]
 
 [[package]]
@@ -2024,7 +2559,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
- "safe_arch",
+ "safe_arch 0.7.4",
+]
+
+[[package]]
+name = "wide"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be"
+dependencies = [
+ "bytemuck",
+ "safe_arch 1.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ default-members = [
     "crates/basin-wasm",
 ]
 # Lockfile lives at the workspace root; member crates share dependency
-# resolution. Per CONTRIBUTING.md tenet 2 (no per-version backend feature gates),
-# all members must agree on a single major version per backend.
+# resolution. Basin's versioned backend features may resolve several releases
+# at once; the library consistently implements the newest enabled release.
 
 [workspace.package]
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ cargo add basin
 ```
 
 Basin works on plain `Vec<f64>` out of the box. Linear-algebra backends are
-opt-in, one feature each:
+opt-in. Use a moving alias to follow the newest supported release:
 
 ```sh
-cargo add basin --features nalgebra  # or: ndarray, faer
+cargo add basin --features nalgebra_latest  # or: ndarray_latest, faer_latest
 ```
 
-Basin's minimum supported Rust version (MSRV) is **1.87.0**. It is held
-deliberately conservative to keep the planned CRAN (R) bindings buildable, so it
-moves rarely and only after checking downstream toolchains.
+Exact version features, such as `nalgebra_v0_34`, keep dependency resolution
+stable. Basin's package minimum supported Rust version (MSRV) is **1.87.0**.
+The one exception is nalgebra 0.35: `nalgebra_v0_35` and `nalgebra_latest`
+require Rust 1.89. The development environment uses Rust 1.89, while CI checks
+the Rust 1.87-compatible feature set separately.
 
 ## Example
 
@@ -117,36 +119,33 @@ See [Solvers] for which backends each one supports.
 ## Backends
 
 Parameters and linear algebra are generic over the backend. `Vec<f64>` needs no
-features; [nalgebra], [ndarray], and [faer] are enabled one feature each, each
-pinning a single major version. First-order and derivative-free solvers run on
-any backend; linear-algebra-heavy solvers may require a specific one and say so
-in their docs.
+features. Each external backend has exact version features and a `*_latest`
+alias that tracks the newest supported release:
 
-Basin pins one major version per backend. Each basin 1.x release supports
-exactly these versions:
+| Backend    | Exact features                            | Moving alias      |
+| ---------- | ----------------------------------------- | ----------------- |
+| [nalgebra] | `nalgebra_v0_32` through `nalgebra_v0_35` | `nalgebra_latest` |
+| [ndarray]  | `ndarray_v0_15` through `ndarray_v0_17`   | `ndarray_latest`  |
+| [faer]     | `faer_v0_22` through `faer_v0_24`         | `faer_latest`     |
 
-  | Backend    | Feature    | Version                            |
-  | ---------- | ---------- | ---------------------------------- |
-  | [nalgebra] | `nalgebra` | 0.34 (with `nalgebra-sparse` 0.11) |
-  | [ndarray]  | `ndarray`  | 0.17                               |
-  | [faer]     | `faer`     | 0.24                               |
+The original features remain frozen for compatibility: `nalgebra` selects
+0.34, `ndarray` selects 0.17, and `faer` selects 0.24. If dependency feature
+unification enables several releases of the same backend, Basin implements the
+newest enabled release. First-order and derivative-free solvers run on any
+backend; linear-algebra-heavy solvers may require a specific one and say so in
+their docs.
 
-`Vec<f64>` is built in and needs no features. A backend major-version bump is a
-breaking change and ships only in a basin major release; within the 1.x series
-these pins are fixed.
+Every nalgebra feature includes its matching `nalgebra-sparse` release:
+0.32/0.9, 0.33/0.10, 0.34/0.11, and 0.35/0.12. Exact acceleration features
+follow the same naming scheme—`nalgebra_v0_34-lapack` and
+`ndarray_v0_16-blas`, for example. The moving aliases are
+`nalgebra_latest-lapack` and `ndarray_latest-blas`; the original acceleration
+features remain frozen at nalgebra 0.34 and ndarray 0.17.
 
-Two backends have opt-in, BLAS/LAPACK-backed acceleration. Both are off by
-default and not wasm-compatible (each links a Fortran/BLAS toolchain), and both
-expect you to bring your own BLAS/LAPACK source crate:
-
-  | Feature           | Effect                                                                                                                                                           |
-  | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | `ndarray-blas`    | Forwards `ndarray/blas` for BLAS-backed ndarray linear algebra.                                                                                                  |
-  | `nalgebra-lapack` | Swaps the nalgebra backend's Cholesky and symmetric eigendecomposition for LAPACK-backed ones (pins `nalgebra-lapack` 0.27, the release tracking nalgebra 0.34). |
-
-The default build is wasm-friendly: no BLAS/LAPACK and no threads. Parallelism
-is behind the opt-in `parallel` feature; BLAS/LAPACK acceleration is behind
-`ndarray-blas` and `nalgebra-lapack`.
+BLAS/LAPACK acceleration is off by default and is not wasm-compatible. These
+features expect you to supply the BLAS/LAPACK symbols at link time. The default
+build remains wasm-friendly and single-threaded; parallelism is behind the
+opt-in `parallel` feature.
 
 ## Citation
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -178,7 +178,7 @@ tasks:
       regenerated JSON. Deliberately not wired into CI — shared runners are too
       noisy for trustworthy microbenchmarks.
     cmds:
-      - cargo bench --features nalgebra,ndarray,faer --bench solver_backends
+      - cargo bench --features nalgebra_latest,ndarray_latest,faer_latest --bench solver_backends
       - cd web && pnpm collect:benchmarks
 
   bench:competitors:

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -14,7 +14,14 @@ keywords = ["optimization", "math", "numerics", "solver", "nonlinear"]
 categories = ["mathematics", "science", "algorithms"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = [
+  "faer_latest",
+  "nalgebra_latest-lapack",
+  "ndarray_latest-blas",
+  "parallel",
+  "problems",
+  "serde",
+]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
@@ -23,34 +30,133 @@ path = "src/lib.rs"
 
 [features]
 default = ["problems"]
-nalgebra = ["dep:nalgebra", "dep:nalgebra-sparse"]
-ndarray = ["dep:ndarray"]
-ndarray-blas = ["ndarray", "ndarray/blas"]
-nalgebra-lapack = [
-  "nalgebra",
+nalgebra = ["nalgebra_v0_34"]
+nalgebra_latest = ["nalgebra_v0_35"]
+nalgebra_all = []
+nalgebra_v0_32 = [
+  "nalgebra_all",
+  "dep:nalgebra_0_32",
+  "dep:nalgebra_sparse_0_9",
+]
+nalgebra_v0_33 = [
+  "nalgebra_all",
+  "dep:nalgebra_0_33",
+  "dep:nalgebra_sparse_0_10",
+]
+nalgebra_v0_34 = [
+  "nalgebra_all",
+  "dep:nalgebra_0_34",
+  "dep:nalgebra_sparse_0_11",
+]
+nalgebra_v0_35 = [
+  "nalgebra_all",
+  "dep:nalgebra",
+  "dep:nalgebra-sparse",
+]
+nalgebra-lapack = ["nalgebra_v0_34-lapack"]
+nalgebra_latest-lapack = ["nalgebra_v0_35-lapack"]
+nalgebra_v0_32-lapack = [
+  "nalgebra_v0_32",
+  "dep:nalgebra_lapack_0_24",
+]
+nalgebra_v0_33-lapack = [
+  "nalgebra_v0_33",
+  "dep:nalgebra_lapack_0_25",
+]
+nalgebra_v0_34-lapack = [
+  "nalgebra_v0_34",
+  "dep:nalgebra_lapack_0_27",
+  "nalgebra_lapack_0_27/lapack-custom",
+]
+nalgebra_v0_35-lapack = [
+  "nalgebra_v0_35",
   "dep:nalgebra-lapack",
   "nalgebra-lapack/lapack-custom",
 ]
-faer = ["dep:faer", "dep:generativity", "dep:faer-traits"]
-parallel = ["dep:rayon", "faer?/rayon"]
+ndarray = ["ndarray_v0_17"]
+ndarray_latest = ["ndarray_v0_17"]
+ndarray_all = []
+ndarray_v0_15 = ["ndarray_all", "dep:ndarray_0_15"]
+ndarray_v0_16 = ["ndarray_all", "dep:ndarray_0_16"]
+ndarray_v0_17 = ["ndarray_all", "dep:ndarray"]
+ndarray-blas = ["ndarray_v0_17-blas"]
+ndarray_latest-blas = ["ndarray_v0_17-blas"]
+ndarray_v0_15-blas = ["ndarray_v0_15", "ndarray_0_15/blas"]
+ndarray_v0_16-blas = ["ndarray_v0_16", "ndarray_0_16/blas"]
+ndarray_v0_17-blas = ["ndarray_v0_17", "ndarray/blas"]
+faer = ["faer_v0_24"]
+faer_latest = ["faer_v0_24"]
+faer_all = []
+faer_v0_22 = [
+  "faer_all",
+  "dep:faer_0_22",
+  "dep:faer_traits_0_22",
+  "dep:generativity",
+]
+faer_v0_23 = [
+  "faer_all",
+  "dep:faer_0_23",
+  "dep:faer_traits_0_23",
+  "dep:generativity",
+]
+faer_v0_24 = [
+  "faer_all",
+  "dep:faer",
+  "dep:faer-traits",
+  "dep:generativity",
+]
+parallel = [
+  "dep:rayon",
+  "faer?/rayon",
+  "faer_0_22?/rayon",
+  "faer_0_23?/rayon",
+]
 serde = [
   "dep:serde",
   "dep:bincode",
   "nalgebra?/serde-serialize",
+  "nalgebra_0_32?/serde-serialize",
+  "nalgebra_0_33?/serde-serialize",
+  "nalgebra_0_34?/serde-serialize",
   "ndarray?/serde",
+  "ndarray_0_15?/serde",
+  "ndarray_0_16?/serde",
 ]
 problems = []
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false, features = ["std"] }
-nalgebra = { version = "0.34", optional = true }
-nalgebra-sparse = { version = "0.11", optional = true }
-nalgebra-lapack = { version = "0.27", optional = true, default-features = false }
+nalgebra_0_32 = { package = "nalgebra", version = "0.32", optional = true }
+nalgebra_0_33 = { package = "nalgebra", version = "0.33", optional = true }
+nalgebra_0_34 = { package = "nalgebra", version = "0.34", optional = true }
+# nalgebra 0.35 requires Rust 1.89. Older backend features preserve Basin's
+# package MSRV of Rust 1.87; `nalgebra_latest` intentionally uses the dev pin.
+nalgebra = { version = "0.35", optional = true }
+nalgebra_sparse_0_9 = { package = "nalgebra-sparse", version = "0.9", optional = true }
+nalgebra_sparse_0_10 = { package = "nalgebra-sparse", version = "0.10", optional = true }
+nalgebra_sparse_0_11 = { package = "nalgebra-sparse", version = "0.11", optional = true }
+nalgebra-sparse = { version = "0.12", optional = true }
+nalgebra_lapack_0_24 = { package = "nalgebra-lapack", version = "0.24", optional = true, default-features = false }
+nalgebra_lapack_0_25 = { package = "nalgebra-lapack", version = "0.25", optional = true, default-features = false }
+nalgebra_lapack_0_27 = { package = "nalgebra-lapack", version = "0.27", optional = true, default-features = false }
+nalgebra-lapack = { version = "0.28", optional = true, default-features = false }
+ndarray_0_15 = { package = "ndarray", version = "0.15", optional = true, default-features = false }
+ndarray_0_16 = { package = "ndarray", version = "0.16", optional = true, default-features = false }
 ndarray = { version = "0.17", optional = true, default-features = false }
+faer_0_22 = { package = "faer", version = "0.22", optional = true, default-features = false, features = [
+  "std",
+  "linalg",
+] }
+faer_0_23 = { package = "faer", version = "0.23", optional = true, default-features = false, features = [
+  "std",
+  "linalg",
+] }
 faer = { version = "0.24", optional = true, default-features = false, features = [
   "std",
   "linalg",
 ] }
+faer_traits_0_22 = { package = "faer-traits", version = "0.22", optional = true, default-features = false }
+faer_traits_0_23 = { package = "faer-traits", version = "0.23", optional = true, default-features = false }
 generativity = { version = "1", optional = true }
 faer-traits = { version = "0.24", optional = true, default-features = false }
 web-time = "1"
@@ -75,9 +181,9 @@ harness = false
 [[bench]]
 name = "lm_backends"
 harness = false
-required-features = ["nalgebra", "faer", "problems"]
+required-features = ["nalgebra_all", "faer_all", "problems"]
 
 [[bench]]
 name = "solver_backends"
 harness = false
-required-features = ["nalgebra", "ndarray", "faer", "problems"]
+required-features = ["nalgebra_all", "ndarray_all", "faer_all", "problems"]

--- a/crates/basin/benches/lm_backends.rs
+++ b/crates/basin/benches/lm_backends.rs
@@ -21,7 +21,8 @@
 //!    identical across backends, so the ratio is pure per-solve backend
 //!    cost.
 //!
-//! Run with `cargo bench --features nalgebra,faer,problems --bench lm_backends`.
+//! Run with
+//! `cargo bench --features nalgebra_latest,faer_latest,problems --bench lm_backends`.
 
 use std::hint::black_box;
 
@@ -34,8 +35,8 @@ use criterion::{
     BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
 
-use faer::{Col, Mat};
-use nalgebra::{DMatrix, DVector};
+use crate::backend_aliases::faer::{Col, Mat};
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 
 /// splitmix64-style deterministic pseudo-random in `[-0.5, 0.5)`, so the
 /// nalgebra and faer inputs are bit-identical (fair timing, same
@@ -238,3 +239,6 @@ criterion_group!(
     bench_full_solve
 );
 criterion_main!(benches);
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/benches/solver_backends.rs
+++ b/crates/basin/benches/solver_backends.rs
@@ -31,7 +31,7 @@
 //! charged to `iter_batched` setup, not the timed routine.
 //!
 //! Run with
-//! `cargo bench --features nalgebra,ndarray,faer --bench solver_backends`.
+//! `cargo bench --features nalgebra_latest,ndarray_latest,faer_latest --bench solver_backends`.
 
 use std::hint::black_box;
 use std::time::Duration;
@@ -49,11 +49,11 @@ use criterion::{
     BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
 
-use faer::sparse::{SparseColMat, Triplet};
-use faer::{Col, Mat};
-use nalgebra::{DMatrix, DVector};
-use nalgebra_sparse::{CooMatrix, CscMatrix};
-use ndarray::Array1;
+use crate::backend_aliases::faer::sparse::{SparseColMat, Triplet};
+use crate::backend_aliases::faer::{Col, Mat};
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
+use crate::backend_aliases::nalgebra_sparse::{CooMatrix, CscMatrix};
+use crate::backend_aliases::ndarray::Array1;
 
 /// Fixed budget, no early stop: identical work across backends (a cap for the
 /// solvers that converge sooner; see the module docs).
@@ -428,3 +428,6 @@ criterion_group! {
     targets = bench_gd, bench_nm, bench_lbfgs, bench_bfgs, bench_cmaes, bench_lm, bench_gn
 }
 criterion_main!(benches);
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/benches/support/backend_aliases.rs
+++ b/crates/basin/benches/support/backend_aliases.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::single_component_path_imports, unused_imports)]
+
+#[cfg(feature = "nalgebra_v0_35")]
+pub(crate) use nalgebra;
+#[cfg(all(
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    )),
+    feature = "nalgebra_v0_32"
+))]
+pub(crate) use nalgebra_0_32 as nalgebra;
+#[cfg(all(
+    not(any(feature = "nalgebra_v0_35", feature = "nalgebra_v0_34")),
+    feature = "nalgebra_v0_33"
+))]
+pub(crate) use nalgebra_0_33 as nalgebra;
+#[cfg(all(not(feature = "nalgebra_v0_35"), feature = "nalgebra_v0_34"))]
+pub(crate) use nalgebra_0_34 as nalgebra;
+
+#[cfg(feature = "nalgebra_v0_35")]
+pub(crate) use nalgebra_sparse;
+#[cfg(all(
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    )),
+    feature = "nalgebra_v0_32"
+))]
+pub(crate) use nalgebra_sparse_0_9 as nalgebra_sparse;
+#[cfg(all(
+    not(any(feature = "nalgebra_v0_35", feature = "nalgebra_v0_34")),
+    feature = "nalgebra_v0_33"
+))]
+pub(crate) use nalgebra_sparse_0_10 as nalgebra_sparse;
+#[cfg(all(not(feature = "nalgebra_v0_35"), feature = "nalgebra_v0_34"))]
+pub(crate) use nalgebra_sparse_0_11 as nalgebra_sparse;
+
+#[cfg(feature = "ndarray_v0_17")]
+pub(crate) use ndarray;
+#[cfg(all(
+    not(any(feature = "ndarray_v0_17", feature = "ndarray_v0_16")),
+    feature = "ndarray_v0_15"
+))]
+pub(crate) use ndarray_0_15 as ndarray;
+#[cfg(all(not(feature = "ndarray_v0_17"), feature = "ndarray_v0_16"))]
+pub(crate) use ndarray_0_16 as ndarray;
+
+#[cfg(feature = "faer_v0_24")]
+pub(crate) use faer;
+#[cfg(all(
+    not(any(feature = "faer_v0_24", feature = "faer_v0_23")),
+    feature = "faer_v0_22"
+))]
+pub(crate) use faer_0_22 as faer;
+#[cfg(all(not(feature = "faer_v0_24"), feature = "faer_v0_23"))]
+pub(crate) use faer_0_23 as faer;

--- a/crates/basin/src/core/augmented_lagrangian.rs
+++ b/crates/basin/src/core/augmented_lagrangian.rs
@@ -140,7 +140,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "nalgebra"))]
+#[cfg(all(test, feature = "nalgebra_all"))]
 mod tests {
     use super::*;
     use nalgebra::{DMatrix, DVector};

--- a/crates/basin/src/core/barrier.rs
+++ b/crates/basin/src/core/barrier.rs
@@ -335,7 +335,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "nalgebra"))]
+#[cfg(all(test, feature = "nalgebra_all"))]
 mod tests {
     use super::*;
     use nalgebra::{DMatrix, DVector};

--- a/crates/basin/src/core/math.rs
+++ b/crates/basin/src/core/math.rs
@@ -233,19 +233,19 @@ mod sample;
 mod scalar;
 mod vec;
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_backend;
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_sparse_backend;
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_backend;
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_backend;
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_sparse_backend;
 
 pub use clamp::ClampInPlace;

--- a/crates/basin/src/core/math/faer_sparse_backend.rs
+++ b/crates/basin/src/core/math/faer_sparse_backend.rs
@@ -2,8 +2,8 @@
 //! [`faer::sparse::SparseColMat<usize, f64>`] (CSC) over
 //! [`faer::Col<f64>`]. Lands in S2b alongside the dense faer backend.
 //!
-//! Faer's sparse stack covers all five `linalg` traits: SpMV/Aᵀ-SpMV
-//! via [`sparse_dense_matmul`], Gram via
+//! Faer's sparse stack covers all five `linalg` traits: SpMV via
+//! [`sparse_dense_matmul`], Aᵀ-SpMV via a CSC column walk, Gram via
 //! [`sparse_sparse_matmul`], SPD solve via supernodal/simplicial
 //! Cholesky ([`SparseColMat::sp_cholesky`]), and least-squares solve
 //! via sparse QR ([`SparseColMat::sp_qr`]). The QR path is the only
@@ -66,19 +66,15 @@ where
             self.nrows(),
             x.nrows()
         );
-        let mut y = Col::<F>::zeros(self.ncols());
-        // SparseRowMatRef impls SparseDenseMatMul, so transposing the
-        // CSC view (giving a CSR view of Aᵀ) lets us reuse the same
-        // entry point without materializing the transpose.
-        sparse_dense_matmul(
-            y.as_mat_mut(),
-            Accum::Replace,
-            self.as_ref().transpose(),
-            x.as_mat(),
-            F::one(),
-            Par::Seq,
-        );
-        y
+        let col_ptr = self.col_ptr();
+        let row_idx = self.row_idx();
+        let vals = self.val();
+
+        Col::from_fn(self.ncols(), |j| {
+            (col_ptr[j]..col_ptr[j + 1])
+                .map(|k| vals[k] * x[row_idx[k]])
+                .sum()
+        })
     }
 }
 

--- a/crates/basin/src/core/math/nalgebra_backend.rs
+++ b/crates/basin/src/core/math/nalgebra_backend.rs
@@ -1,3 +1,18 @@
+#[cfg(all(
+    feature = "nalgebra_v0_32",
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    ))
+))]
+use nalgebra::{ClosedAdd as ClosedAddAssign, ClosedMul as ClosedMulAssign};
+#[cfg(any(
+    feature = "nalgebra_v0_35",
+    feature = "nalgebra_v0_34",
+    feature = "nalgebra_v0_33"
+))]
+use nalgebra::{ClosedAddAssign, ClosedMulAssign};
 use nalgebra::{DMatrix, DVector, Dim, Matrix, Storage, StorageMut};
 use rand::{Rng, RngExt};
 use rand_distr::{Distribution, StandardNormal, uniform::SampleUniform};
@@ -21,6 +36,62 @@ use super::{
     Dot, FloorZerosInPlace, NegInPlace, NormInfinity, NormSquared,
     ScaleInPlace, ScaledAdd, VectorIndex, VectorLen,
 };
+
+macro_rules! if_selected_nalgebra_lapack {
+    ($item:item) => {
+        #[cfg(any(
+            feature = "nalgebra_v0_35-lapack",
+            all(
+                not(feature = "nalgebra_v0_35"),
+                feature = "nalgebra_v0_34-lapack"
+            ),
+            all(
+                not(any(
+                    feature = "nalgebra_v0_35",
+                    feature = "nalgebra_v0_34"
+                )),
+                feature = "nalgebra_v0_33-lapack"
+            ),
+            all(
+                not(any(
+                    feature = "nalgebra_v0_35",
+                    feature = "nalgebra_v0_34",
+                    feature = "nalgebra_v0_33"
+                )),
+                feature = "nalgebra_v0_32-lapack"
+            )
+        ))]
+        $item
+    };
+}
+
+macro_rules! if_not_selected_nalgebra_lapack {
+    ($item:item) => {
+        #[cfg(not(any(
+            feature = "nalgebra_v0_35-lapack",
+            all(
+                not(feature = "nalgebra_v0_35"),
+                feature = "nalgebra_v0_34-lapack"
+            ),
+            all(
+                not(any(
+                    feature = "nalgebra_v0_35",
+                    feature = "nalgebra_v0_34"
+                )),
+                feature = "nalgebra_v0_33-lapack"
+            ),
+            all(
+                not(any(
+                    feature = "nalgebra_v0_35",
+                    feature = "nalgebra_v0_34",
+                    feature = "nalgebra_v0_33"
+                )),
+                feature = "nalgebra_v0_32-lapack"
+            )
+        )))]
+        $item
+    };
+}
 
 // `F: Scalar` (basin's alias) bundles `Float + FromPrimitive + Sum + Debug +
 // Default + 'static`, which transitively satisfies `nalgebra::Scalar`
@@ -390,7 +461,7 @@ where
 
 impl<F> MatVec<DVector<F>> for DMatrix<F>
 where
-    F: Scalar + nalgebra::ClosedAddAssign + nalgebra::ClosedMulAssign,
+    F: Scalar + ClosedAddAssign + ClosedMulAssign,
 {
     fn matvec(&self, x: &DVector<F>) -> DVector<F> {
         assert_eq!(
@@ -406,7 +477,7 @@ where
 
 impl<F> MatTransposeVec<DVector<F>> for DMatrix<F>
 where
-    F: Scalar + nalgebra::ClosedAddAssign + nalgebra::ClosedMulAssign,
+    F: Scalar + ClosedAddAssign + ClosedMulAssign,
 {
     fn mat_transpose_vec(&self, x: &DVector<F>) -> DVector<F> {
         assert_eq!(
@@ -422,7 +493,7 @@ where
 
 impl<F> GramMatrix for DMatrix<F>
 where
-    F: Scalar + nalgebra::ClosedAddAssign + nalgebra::ClosedMulAssign,
+    F: Scalar + ClosedAddAssign + ClosedMulAssign,
 {
     fn gram(&self) -> Self {
         // tr_mul(self) computes Aᵀ A in one pass without an explicit transpose.
@@ -463,7 +534,7 @@ impl<F: Scalar> MatDiagonal<DVector<F>> for DMatrix<F> {
 
 impl<F> AddDiagonalVectorInPlace<DVector<F>> for DMatrix<F>
 where
-    F: Scalar + nalgebra::ClosedAddAssign,
+    F: Scalar + ClosedAddAssign,
 {
     fn add_diagonal_vector_in_place(&mut self, diag: &DVector<F>) {
         assert_eq!(
@@ -513,7 +584,7 @@ impl<F: Scalar> DenseMatrixFromFn<F> for DVector<F> {
 // Pure-Rust symmetric eigendecomposition (default), generic over every
 // `F: RealField`. Swapped for the LAPACK impl below under `nalgebra-lapack`;
 // the two are mutually exclusive (`#[cfg]`).
-#[cfg(not(feature = "nalgebra-lapack"))]
+if_not_selected_nalgebra_lapack! {
 impl<F> SymmetricEigen<DVector<F>> for DMatrix<F>
 where
     F: Scalar + nalgebra::RealField,
@@ -537,6 +608,7 @@ where
             .ok_or(SymmetricEigenError::Failed)
     }
 }
+}
 
 // LAPACK-backed symmetric eigendecomposition (`nalgebra-lapack` feature).
 // Behaviorally interchangeable with the pure-Rust impl above for the LAPACK
@@ -548,7 +620,7 @@ where
 // bound, unlike `CholeskyScalar` above. f64 and f32 are the only scalars
 // LAPACK's `dsyev`/`ssyev` cover; see the `nalgebra-lapack` feature note in
 // `Cargo.toml`.
-#[cfg(feature = "nalgebra-lapack")]
+if_selected_nalgebra_lapack! {
 macro_rules! lapack_symmetric_eigen_impl {
     ($scalar:ty) => {
         impl SymmetricEigen<DVector<$scalar>> for DMatrix<$scalar> {
@@ -572,15 +644,18 @@ macro_rules! lapack_symmetric_eigen_impl {
         }
     };
 }
+}
 
-#[cfg(feature = "nalgebra-lapack")]
+if_selected_nalgebra_lapack! {
 lapack_symmetric_eigen_impl!(f64);
-#[cfg(feature = "nalgebra-lapack")]
+}
+if_selected_nalgebra_lapack! {
 lapack_symmetric_eigen_impl!(f32);
+}
 
 impl<F> RankOneUpdate<DVector<F>, F> for DMatrix<F>
 where
-    F: Scalar + nalgebra::ClosedAddAssign + nalgebra::ClosedMulAssign,
+    F: Scalar + ClosedAddAssign + ClosedMulAssign,
 {
     fn rank_one_update(&mut self, alpha: F, v: &DVector<F>) {
         assert_eq!(
@@ -606,7 +681,7 @@ where
 
 impl<F> GeneralRankOneUpdate<DVector<F>, F> for DMatrix<F>
 where
-    F: Scalar + nalgebra::ClosedAddAssign + nalgebra::ClosedMulAssign,
+    F: Scalar + ClosedAddAssign + ClosedMulAssign,
 {
     fn general_rank_one_update(
         &mut self,
@@ -645,7 +720,7 @@ where
 // Pure-Rust Cholesky (default). Generic over every `F: ComplexField`. Swapped
 // out for the LAPACK impl below when the `nalgebra-lapack` feature is on; the
 // two are mutually exclusive (`#[cfg]`) so coherence is never violated.
-#[cfg(not(feature = "nalgebra-lapack"))]
+if_not_selected_nalgebra_lapack! {
 impl<F> LinearSolveSpd<DVector<F>> for DMatrix<F>
 where
     F: Scalar + nalgebra::ComplexField,
@@ -676,6 +751,7 @@ where
             .map(|chol| chol.solve(b))
     }
 }
+}
 
 // LAPACK-backed Cholesky (`nalgebra-lapack` feature). Behaviorally
 // interchangeable with the pure-Rust impl above for the LAPACK scalar set:
@@ -683,7 +759,7 @@ where
 // The bound narrows from any `F: ComplexField` to `nalgebra_lapack`'s
 // `CholeskyScalar` (f32/f64 and their complex counterparts); see the
 // `nalgebra-lapack` feature note in `Cargo.toml`.
-#[cfg(feature = "nalgebra-lapack")]
+if_selected_nalgebra_lapack! {
 impl<F> LinearSolveSpd<DVector<F>> for DMatrix<F>
 where
     F: Scalar + nalgebra_lapack::CholeskyScalar + num_traits::Zero,
@@ -713,6 +789,7 @@ where
             .ok_or(LinearSolveError::NotPositiveDefinite)?;
         chol.solve(b).ok_or(LinearSolveError::NotPositiveDefinite)
     }
+}
 }
 
 #[cfg(test)]

--- a/crates/basin/src/core/math/nalgebra_sparse_backend.rs
+++ b/crates/basin/src/core/math/nalgebra_sparse_backend.rs
@@ -13,6 +13,26 @@
 //! Reach for the faer-sparse backend if you need least-squares on
 //! sparse `J`.
 
+#[cfg(all(
+    feature = "nalgebra_v0_32",
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    ))
+))]
+use nalgebra::{
+    ClosedAdd as ClosedAddAssign, ClosedDiv as ClosedDivAssign,
+    ClosedMul as ClosedMulAssign, ClosedSub as ClosedSubAssign,
+};
+#[cfg(any(
+    feature = "nalgebra_v0_35",
+    feature = "nalgebra_v0_34",
+    feature = "nalgebra_v0_33"
+))]
+use nalgebra::{
+    ClosedAddAssign, ClosedDivAssign, ClosedMulAssign, ClosedSubAssign,
+};
 use nalgebra::{DMatrix, DVector};
 use nalgebra_sparse::factorization::CscCholesky;
 use nalgebra_sparse::ops::Op;
@@ -32,7 +52,7 @@ use super::linalg::{
 
 impl<F> MatVec<DVector<F>> for CscMatrix<F>
 where
-    F: Scalar + nalgebra::ClosedAddAssign + nalgebra::ClosedMulAssign,
+    F: Scalar + ClosedAddAssign + ClosedMulAssign,
 {
     fn matvec(&self, x: &DVector<F>) -> DVector<F> {
         assert_eq!(
@@ -61,7 +81,7 @@ where
 
 impl<F> MatTransposeVec<DVector<F>> for CscMatrix<F>
 where
-    F: Scalar + nalgebra::ClosedAddAssign + nalgebra::ClosedMulAssign,
+    F: Scalar + ClosedAddAssign + ClosedMulAssign,
 {
     fn mat_transpose_vec(&self, x: &DVector<F>) -> DVector<F> {
         assert_eq!(
@@ -91,10 +111,10 @@ where
 impl<F> GramMatrix for CscMatrix<F>
 where
     F: Scalar
-        + nalgebra::ClosedAddAssign
-        + nalgebra::ClosedSubAssign
-        + nalgebra::ClosedMulAssign
-        + nalgebra::ClosedDivAssign
+        + ClosedAddAssign
+        + ClosedSubAssign
+        + ClosedMulAssign
+        + ClosedDivAssign
         + std::ops::Neg<Output = F>,
 {
     fn gram(&self) -> Self {

--- a/crates/basin/src/core/numdiff.rs
+++ b/crates/basin/src/core/numdiff.rs
@@ -1090,7 +1090,7 @@ mod tests {
         assert_eq!(wrapped.upper(), &upper);
     }
 
-    #[cfg(all(feature = "problems", feature = "nalgebra"))]
+    #[cfg(all(feature = "problems", feature = "nalgebra_all"))]
     mod nalgebra_matrix {
         use super::*;
         use crate::problems::rosenbrock::{Rosenbrock, RosenbrockResiduals};
@@ -1187,7 +1187,7 @@ mod tests {
         }
     }
 
-    #[cfg(all(feature = "problems", feature = "faer"))]
+    #[cfg(all(feature = "problems", feature = "faer_all"))]
     mod faer_matrix {
         use super::*;
         use crate::problems::rosenbrock::RosenbrockResiduals;

--- a/crates/basin/src/core/problem.rs
+++ b/crates/basin/src/core/problem.rs
@@ -453,7 +453,7 @@ pub trait Residual {
 /// # Examples
 ///
 /// ```
-/// # #[cfg(feature = "nalgebra")] {
+/// # #[cfg(feature = "nalgebra_v0_35")] {
 /// use basin::{Jacobian, Residual};
 /// use nalgebra::{DMatrix, DVector};
 ///
@@ -567,7 +567,7 @@ pub trait Jacobian: Residual {
 /// # Examples
 ///
 /// ```
-/// # #[cfg(feature = "nalgebra")] {
+/// # #[cfg(feature = "nalgebra_v0_35")] {
 /// use basin::{CostFunction, Gradient, Hessian};
 /// use nalgebra::{DMatrix, DVector};
 ///

--- a/crates/basin/src/core/state.rs
+++ b/crates/basin/src/core/state.rs
@@ -614,7 +614,7 @@ impl IntoInitialSimplex<Self> for Vec<f64> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 impl IntoInitialSimplex<Self> for nalgebra::DVector<f64> {
     fn into_initial_simplex(self, relative_step: f64) -> Vec<Self> {
         let n = self.len();
@@ -633,7 +633,7 @@ impl IntoInitialSimplex<Self> for nalgebra::DVector<f64> {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 impl IntoInitialSimplex<Self> for faer::Col<f64> {
     fn into_initial_simplex(self, relative_step: f64) -> Vec<Self> {
         let n = self.nrows();
@@ -652,7 +652,7 @@ impl IntoInitialSimplex<Self> for faer::Col<f64> {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 impl IntoInitialSimplex<ndarray::Array1<f64>> for ndarray::Array1<f64> {
     fn into_initial_simplex(
         self,
@@ -865,7 +865,7 @@ pub type DenseQuasiNewtonState<F = f64> =
 /// `NalgebraQuasiNewtonState::new(x)` instead of
 /// `QuasiNewtonState::<DVector<f64>, DMatrix<f64>>::new(x)`. The scalar `F`
 /// defaults to `f64`.
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 pub type NalgebraQuasiNewtonState<F = f64> =
     QuasiNewtonState<nalgebra::DVector<F>, nalgebra::DMatrix<F>, F>;
 
@@ -875,7 +875,7 @@ pub type NalgebraQuasiNewtonState<F = f64> =
 /// `FaerQuasiNewtonState::new(x)` instead of
 /// `QuasiNewtonState::<Col<f64>, Mat<f64>>::new(x)`. The scalar `F` defaults
 /// to `f64`.
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 pub type FaerQuasiNewtonState<F = f64> =
     QuasiNewtonState<faer::Col<F>, faer::Mat<F>, F>;
 
@@ -885,7 +885,7 @@ pub type FaerQuasiNewtonState<F = f64> =
 /// `NdarrayQuasiNewtonState::new(x)` instead of
 /// `QuasiNewtonState::<Array1<f64>, Array2<f64>>::new(x)`. The scalar `F`
 /// defaults to `f64`.
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 pub type NdarrayQuasiNewtonState<F = f64> =
     QuasiNewtonState<ndarray::Array1<F>, ndarray::Array2<F>, F>;
 

--- a/crates/basin/src/lib.rs
+++ b/crates/basin/src/lib.rs
@@ -138,32 +138,34 @@
 //! # Backends
 //!
 //! Parameters and linear algebra are generic over the backend. `Vec<f64>` needs
-//! no features; nalgebra, ndarray, and faer are enabled one feature each, each
-//! pinning a single major version. Basin pins one major version per backend;
-//! each Basin 1.x release supports exactly these versions:
+//! no features. Each external backend has exact version features and a moving
+//! alias:
 //!
-//! | Backend    | Feature      | Version                            |
-//! | ---------- | ------------ | ---------------------------------- |
-//! | nalgebra   | `nalgebra`   | 0.34 (with `nalgebra-sparse` 0.11) |
-//! | ndarray    | `ndarray`    | 0.17                               |
-//! | faer       | `faer`       | 0.24                               |
+//! | Backend  | Exact features                            | Moving alias      |
+//! | -------- | ----------------------------------------- | ----------------- |
+//! | nalgebra | `nalgebra_v0_32` through `nalgebra_v0_35` | `nalgebra_latest` |
+//! | ndarray  | `ndarray_v0_15` through `ndarray_v0_17`   | `ndarray_latest`  |
+//! | faer     | `faer_v0_22` through `faer_v0_24`         | `faer_latest`     |
 //!
-//! `Vec<f64>` is the built-in default backend, so no feature is needed for that.
+//! The original features remain frozen for Basin 1.x compatibility:
+//! `nalgebra` selects 0.34, `ndarray` selects 0.17, and `faer` selects 0.24.
+//! If dependency feature unification enables several releases of one backend,
+//! Basin implements the newest enabled release.
 //!
-//! A backend major-version bump is a breaking change and ships only in a Basin
-//! major release; within the 1.x series these pins are fixed.
+//! Each nalgebra release includes its matching `nalgebra-sparse` release:
+//! 0.32/0.9, 0.33/0.10, 0.34/0.11, and 0.35/0.12. Versioned acceleration uses
+//! the `nalgebra_v0_XX-lapack` and `ndarray_v0_XX-blas` features. The moving
+//! aliases are `nalgebra_latest-lapack` and `ndarray_latest-blas`; the original
+//! `nalgebra-lapack` and `ndarray-blas` features remain frozen at nalgebra 0.34
+//! and ndarray 0.17.
 //!
-//! Two backends have opt-in, BLAS/LAPACK-backed acceleration. Both are off by
-//! default and not wasm-compatible (each links a Fortran/BLAS toolchain), and
-//! both expect you to bring your own BLAS/LAPACK source crate:
+//! BLAS/LAPACK acceleration is off by default, is not wasm-compatible, and
+//! expects the application to supply BLAS/LAPACK symbols at link time. The
+//! default build is wasm-friendly and single-threaded; parallelism is behind
+//! the opt-in `parallel` feature.
 //!
-//! | Feature           | Effect                                                                                        |
-//! | ----------------- | --------------------------------------------------------------------------------------------- |
-//! | `ndarray-blas`    | Forwards `ndarray/blas` for BLAS-backed ndarray linear algebra.                                |
-//! | `nalgebra-lapack` | Swaps the nalgebra backend's Cholesky/symmetric eigendecomposition for LAPACK-backed ones.   |
-//!
-//! The default build is wasm-friendly: no BLAS/LAPACK and no threads.
-//! Parallelism is behind the opt-in `parallel` feature.
+//! Basin's package MSRV is Rust 1.87. `nalgebra_v0_35` and
+//! `nalgebra_latest` require Rust 1.89 because nalgebra 0.35 does.
 //!
 //! # Citation
 //!
@@ -194,6 +196,125 @@
 #![cfg_attr(docsrs, feature(doc_cfg), doc(auto_cfg))]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
+
+// Cargo features are additive, so several versions of one backend may be
+// enabled after dependency feature unification. Bind the unversioned crate
+// name to the newest enabled version, matching argmin-math's selection model.
+#[cfg(feature = "nalgebra_v0_35")]
+extern crate nalgebra;
+#[cfg(all(
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    )),
+    feature = "nalgebra_v0_32"
+))]
+extern crate nalgebra_0_32 as nalgebra;
+#[cfg(all(
+    not(any(feature = "nalgebra_v0_35", feature = "nalgebra_v0_34")),
+    feature = "nalgebra_v0_33"
+))]
+extern crate nalgebra_0_33 as nalgebra;
+#[cfg(all(not(feature = "nalgebra_v0_35"), feature = "nalgebra_v0_34"))]
+extern crate nalgebra_0_34 as nalgebra;
+
+#[cfg(feature = "nalgebra_v0_35")]
+extern crate nalgebra_sparse;
+#[cfg(all(
+    not(any(feature = "nalgebra_v0_35", feature = "nalgebra_v0_34")),
+    feature = "nalgebra_v0_33"
+))]
+extern crate nalgebra_sparse_0_10 as nalgebra_sparse;
+#[cfg(all(not(feature = "nalgebra_v0_35"), feature = "nalgebra_v0_34"))]
+extern crate nalgebra_sparse_0_11 as nalgebra_sparse;
+#[cfg(all(
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    )),
+    feature = "nalgebra_v0_32"
+))]
+extern crate nalgebra_sparse_0_9 as nalgebra_sparse;
+
+#[cfg(feature = "nalgebra_v0_35-lapack")]
+extern crate nalgebra_lapack;
+#[cfg(all(
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    )),
+    feature = "nalgebra_v0_32-lapack"
+))]
+extern crate nalgebra_lapack_0_24 as nalgebra_lapack;
+#[cfg(all(
+    not(any(feature = "nalgebra_v0_35", feature = "nalgebra_v0_34")),
+    feature = "nalgebra_v0_33-lapack"
+))]
+extern crate nalgebra_lapack_0_25 as nalgebra_lapack;
+#[cfg(all(not(feature = "nalgebra_v0_35"), feature = "nalgebra_v0_34-lapack"))]
+extern crate nalgebra_lapack_0_27 as nalgebra_lapack;
+
+#[cfg(feature = "ndarray_v0_17")]
+extern crate ndarray;
+#[cfg(all(
+    not(any(feature = "ndarray_v0_17", feature = "ndarray_v0_16")),
+    feature = "ndarray_v0_15"
+))]
+extern crate ndarray_0_15 as ndarray;
+#[cfg(all(not(feature = "ndarray_v0_17"), feature = "ndarray_v0_16"))]
+extern crate ndarray_0_16 as ndarray;
+
+#[cfg(feature = "faer_v0_24")]
+extern crate faer;
+#[cfg(all(
+    not(any(feature = "faer_v0_24", feature = "faer_v0_23")),
+    feature = "faer_v0_22"
+))]
+extern crate faer_0_22 as faer;
+#[cfg(all(not(feature = "faer_v0_24"), feature = "faer_v0_23"))]
+extern crate faer_0_23 as faer;
+
+#[cfg(feature = "faer_v0_24")]
+extern crate faer_traits;
+#[cfg(all(
+    not(any(feature = "faer_v0_24", feature = "faer_v0_23")),
+    feature = "faer_v0_22"
+))]
+extern crate faer_traits_0_22 as faer_traits;
+#[cfg(all(not(feature = "faer_v0_24"), feature = "faer_v0_23"))]
+extern crate faer_traits_0_23 as faer_traits;
+
+#[cfg(all(
+    feature = "nalgebra_all",
+    not(any(
+        feature = "nalgebra_v0_32",
+        feature = "nalgebra_v0_33",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_35"
+    ))
+))]
+compile_error!("`nalgebra_all` is internal; enable a `nalgebra_v*` feature");
+#[cfg(all(
+    feature = "ndarray_all",
+    not(any(
+        feature = "ndarray_v0_15",
+        feature = "ndarray_v0_16",
+        feature = "ndarray_v0_17"
+    ))
+))]
+compile_error!("`ndarray_all` is internal; enable an `ndarray_v*` feature");
+#[cfg(all(
+    feature = "faer_all",
+    not(any(
+        feature = "faer_v0_22",
+        feature = "faer_v0_23",
+        feature = "faer_v0_24"
+    ))
+))]
+compile_error!("`faer_all` is internal; enable a `faer_v*` feature");
 
 pub mod core;
 pub mod line_search;
@@ -238,11 +359,11 @@ pub use crate::core::problem::{
     MiniBatchGradient, Problem, Residual,
 };
 pub use crate::core::solver::Solver;
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 pub use crate::core::state::FaerQuasiNewtonState;
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 pub use crate::core::state::NalgebraQuasiNewtonState;
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 pub use crate::core::state::NdarrayQuasiNewtonState;
 pub use crate::core::state::{
     BasicPopulationState, BasicSimplexState, BasicState, BobyqaState,

--- a/crates/basin/src/problems/ackley.rs
+++ b/crates/basin/src/problems/ackley.rs
@@ -120,7 +120,7 @@ impl CostFunction for Ackley<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Ackley, ackley};
     use crate::CostFunction;
@@ -139,7 +139,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Ackley, ackley};
     use crate::CostFunction;
@@ -158,7 +158,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::{A, Ackley, B};
     use crate::CostFunction;
@@ -245,7 +245,7 @@ impl BoxConstraints for AckleyBoxed<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_boxed_impl {
     use super::{AckleyBoxed, STANDARD_LOWER, STANDARD_UPPER, ackley};
     use crate::{BoxConstraints, CostFunction};
@@ -284,7 +284,7 @@ mod nalgebra_boxed_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_boxed_impl {
     use super::{AckleyBoxed, STANDARD_LOWER, STANDARD_UPPER, ackley};
     use crate::{BoxConstraints, CostFunction};
@@ -323,7 +323,7 @@ mod ndarray_boxed_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_boxed_impl {
     use super::{A, AckleyBoxed, B, STANDARD_LOWER, STANDARD_UPPER};
     use crate::{BoxConstraints, CostFunction};

--- a/crates/basin/src/problems/beale.rs
+++ b/crates/basin/src/problems/beale.rs
@@ -114,7 +114,7 @@ impl Gradient for Beale<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Beale, beale, beale_gradient};
     use crate::{CostFunction, Gradient};
@@ -145,7 +145,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Beale, beale, beale_gradient};
     use crate::{CostFunction, Gradient};
@@ -179,7 +179,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Beale;
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/problems/booth.rs
+++ b/crates/basin/src/problems/booth.rs
@@ -328,7 +328,7 @@ impl BoxConstraints for BoothBoxedResiduals<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{
         Booth, BoothBoxed, BoothBoxedResiduals, BoothResiduals, booth,
@@ -481,7 +481,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{
         Booth, BoothBoxed, BoothBoxedResiduals, BoothResiduals, booth,
@@ -650,7 +650,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::{
         Booth, BoothBoxed, BoothBoxedResiduals, BoothResiduals,

--- a/crates/basin/src/problems/bukin.rs
+++ b/crates/basin/src/problems/bukin.rs
@@ -92,7 +92,7 @@ impl CostFunction for BukinN6<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{BukinN6, bukin_n6};
     use crate::CostFunction;
@@ -111,7 +111,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{BukinN6, bukin_n6};
     use crate::CostFunction;
@@ -130,7 +130,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::BukinN6;
     use crate::CostFunction;

--- a/crates/basin/src/problems/constrained_quadratic.rs
+++ b/crates/basin/src/problems/constrained_quadratic.rs
@@ -66,7 +66,7 @@ impl<M, V> HasSpec for ConstrainedQuadratic<M, V> {
     const SPEC: &'static ProblemSpec = &CONSTRAINED_QUADRATIC_SPEC;
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::ConstrainedQuadratic;
     use crate::{CostFunction, Gradient, LinearInequalityConstraints};
@@ -107,7 +107,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::ConstrainedQuadratic;
     use crate::{CostFunction, Gradient, LinearInequalityConstraints};
@@ -191,7 +191,7 @@ mod vec_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::ConstrainedQuadratic;
     use crate::{CostFunction, Gradient, LinearInequalityConstraints};

--- a/crates/basin/src/problems/cross_in_tray.rs
+++ b/crates/basin/src/problems/cross_in_tray.rs
@@ -88,7 +88,7 @@ impl CostFunction for CrossInTray<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{CrossInTray, cross_in_tray};
     use crate::CostFunction;
@@ -107,7 +107,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{CrossInTray, cross_in_tray};
     use crate::CostFunction;
@@ -126,7 +126,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::CrossInTray;
     use crate::CostFunction;

--- a/crates/basin/src/problems/easom.rs
+++ b/crates/basin/src/problems/easom.rs
@@ -115,7 +115,7 @@ impl Gradient for Easom<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Easom, easom, easom_gradient};
     use crate::{CostFunction, Gradient};
@@ -146,7 +146,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Easom, easom, easom_gradient};
     use crate::{CostFunction, Gradient};
@@ -180,7 +180,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Easom;
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/problems/eggholder.rs
+++ b/crates/basin/src/problems/eggholder.rs
@@ -87,7 +87,7 @@ impl CostFunction for Eggholder<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Eggholder, eggholder};
     use crate::CostFunction;
@@ -106,7 +106,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Eggholder, eggholder};
     use crate::CostFunction;
@@ -125,7 +125,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Eggholder;
     use crate::CostFunction;

--- a/crates/basin/src/problems/equality_constrained_quadratic.rs
+++ b/crates/basin/src/problems/equality_constrained_quadratic.rs
@@ -70,7 +70,7 @@ impl<M, V> HasSpec for EqualityConstrainedQuadratic<M, V> {
     const SPEC: &'static ProblemSpec = &EQUALITY_CONSTRAINED_QUADRATIC_SPEC;
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::EqualityConstrainedQuadratic;
     use crate::{CostFunction, Gradient, LinearEqualityConstraints};
@@ -111,7 +111,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::EqualityConstrainedQuadratic;
     use crate::{CostFunction, Gradient, LinearEqualityConstraints};
@@ -197,7 +197,7 @@ mod vec_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::EqualityConstrainedQuadratic;
     use crate::{CostFunction, Gradient, LinearEqualityConstraints};

--- a/crates/basin/src/problems/exponential_fit.rs
+++ b/crates/basin/src/problems/exponential_fit.rs
@@ -188,7 +188,7 @@ mod vec_impl {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{
         ExponentialFit, exponential_fit, exponential_fit_jacobian,
@@ -243,7 +243,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{
         ExponentialFit, exponential_fit, exponential_fit_jacobian,
@@ -308,7 +308,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::{
         ExponentialFit, exponential_fit, exponential_fit_jacobian,

--- a/crates/basin/src/problems/goldstein_price.rs
+++ b/crates/basin/src/problems/goldstein_price.rs
@@ -145,7 +145,7 @@ impl Gradient for GoldsteinPrice<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{GoldsteinPrice, goldstein_price, goldstein_price_gradient};
     use crate::{CostFunction, Gradient};
@@ -176,7 +176,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{GoldsteinPrice, goldstein_price, goldstein_price_gradient};
     use crate::{CostFunction, Gradient};
@@ -210,7 +210,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::GoldsteinPrice;
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/problems/himmelblau.rs
+++ b/crates/basin/src/problems/himmelblau.rs
@@ -118,7 +118,7 @@ impl Gradient for Himmelblau<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Himmelblau, himmelblau, himmelblau_gradient};
     use crate::{CostFunction, Gradient};
@@ -149,7 +149,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Himmelblau, himmelblau, himmelblau_gradient};
     use crate::{CostFunction, Gradient};
@@ -183,7 +183,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Himmelblau;
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/problems/holder_table.rs
+++ b/crates/basin/src/problems/holder_table.rs
@@ -88,7 +88,7 @@ impl CostFunction for HolderTable<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{HolderTable, holder_table};
     use crate::CostFunction;
@@ -107,7 +107,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{HolderTable, holder_table};
     use crate::CostFunction;
@@ -126,7 +126,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::HolderTable;
     use crate::CostFunction;

--- a/crates/basin/src/problems/levy.rs
+++ b/crates/basin/src/problems/levy.rs
@@ -156,7 +156,7 @@ impl Gradient for Levy<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Levy, levy, levy_gradient};
     use crate::{CostFunction, Gradient};
@@ -187,7 +187,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Levy, levy, levy_gradient};
     use crate::{CostFunction, Gradient};
@@ -221,7 +221,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::{Levy, levy, levy_gradient};
     use crate::{CostFunction, Gradient};
@@ -320,7 +320,7 @@ impl BoxConstraints for LevyBoxed<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_boxed_impl {
     use super::{
         LevyBoxed, STANDARD_LOWER, STANDARD_UPPER, levy, levy_gradient,
@@ -373,7 +373,7 @@ mod nalgebra_boxed_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_boxed_impl {
     use super::{
         LevyBoxed, STANDARD_LOWER, STANDARD_UPPER, levy, levy_gradient,
@@ -429,7 +429,7 @@ mod ndarray_boxed_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_boxed_impl {
     use super::{
         LevyBoxed, STANDARD_LOWER, STANDARD_UPPER, levy, levy_gradient,

--- a/crates/basin/src/problems/matyas.rs
+++ b/crates/basin/src/problems/matyas.rs
@@ -110,7 +110,7 @@ impl Gradient for Matyas<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Matyas, matyas, matyas_gradient};
     use crate::{CostFunction, Gradient};
@@ -141,7 +141,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Matyas, matyas, matyas_gradient};
     use crate::{CostFunction, Gradient};
@@ -175,7 +175,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Matyas;
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/problems/mccormick.rs
+++ b/crates/basin/src/problems/mccormick.rs
@@ -131,7 +131,7 @@ impl Gradient for McCormick<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{McCormick, mccormick, mccormick_gradient};
     use crate::{CostFunction, Gradient};
@@ -162,7 +162,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{McCormick, mccormick, mccormick_gradient};
     use crate::{CostFunction, Gradient};
@@ -196,7 +196,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::McCormick;
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/problems/picheny.rs
+++ b/crates/basin/src/problems/picheny.rs
@@ -143,7 +143,7 @@ impl Gradient for Picheny<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Picheny, picheny, picheny_gradient};
     use crate::{CostFunction, Gradient};
@@ -174,7 +174,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Picheny, picheny, picheny_gradient};
     use crate::{CostFunction, Gradient};
@@ -208,7 +208,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     // Routes through the slice-based primitives via a small stack array, since
     // the math is fixed-2D and reuses the Goldstein-Price free functions.

--- a/crates/basin/src/problems/powell_singular.rs
+++ b/crates/basin/src/problems/powell_singular.rs
@@ -191,7 +191,7 @@ impl Jacobian for PowellSingular<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{
         PowellSingular, powell_singular, powell_singular_jacobian,
@@ -241,7 +241,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{
         PowellSingular, powell_singular, powell_singular_jacobian,
@@ -299,7 +299,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::{PowellSingular, SQRT_5, SQRT_10, powell_singular_jacobian};
     use crate::{CostFunction, Jacobian, Residual};
@@ -473,7 +473,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "nalgebra")]
+    #[cfg(feature = "nalgebra_all")]
     mod nalgebra_jacobian_tests {
         use super::super::PowellSingular;
         use crate::{GramMatrix, Jacobian, LinearSolveError, LinearSolveSpd};
@@ -518,7 +518,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "faer")]
+    #[cfg(feature = "faer_all")]
     mod faer_jacobian_tests {
         use super::super::PowellSingular;
         use crate::{GramMatrix, Jacobian, LinearSolveError, LinearSolveSpd};

--- a/crates/basin/src/problems/rastrigin.rs
+++ b/crates/basin/src/problems/rastrigin.rs
@@ -129,7 +129,7 @@ impl CostFunction for Rastrigin<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Rastrigin, rastrigin};
     use crate::CostFunction;
@@ -148,7 +148,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Rastrigin, rastrigin};
     use crate::CostFunction;
@@ -167,7 +167,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::{A, Rastrigin};
     use crate::CostFunction;
@@ -256,7 +256,7 @@ impl BoxConstraints for RastriginBoxed<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_boxed_impl {
     use super::{RastriginBoxed, STANDARD_LOWER, STANDARD_UPPER, rastrigin};
     use crate::{BoxConstraints, CostFunction};
@@ -295,7 +295,7 @@ mod nalgebra_boxed_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_boxed_impl {
     use super::{RastriginBoxed, STANDARD_LOWER, STANDARD_UPPER, rastrigin};
     use crate::{BoxConstraints, CostFunction};
@@ -334,7 +334,7 @@ mod ndarray_boxed_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_boxed_impl {
     use super::{A, RastriginBoxed, STANDARD_LOWER, STANDARD_UPPER};
     use crate::{BoxConstraints, CostFunction};

--- a/crates/basin/src/problems/rosenbrock.rs
+++ b/crates/basin/src/problems/rosenbrock.rs
@@ -107,7 +107,7 @@ impl Gradient for Rosenbrock<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Rosenbrock, rosenbrock, rosenbrock_gradient};
     use crate::{CostFunction, Gradient};
@@ -138,7 +138,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Rosenbrock, rosenbrock, rosenbrock_gradient};
     use crate::{CostFunction, Gradient};
@@ -173,7 +173,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Rosenbrock;
     use crate::{CostFunction, Gradient};
@@ -322,7 +322,7 @@ impl Jacobian for RosenbrockResiduals<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_residuals_impl {
     use super::{
         RosenbrockResiduals, rosenbrock, rosenbrock_residuals,
@@ -370,7 +370,7 @@ mod nalgebra_residuals_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_residuals_impl {
     use super::{
         RosenbrockResiduals, rosenbrock, rosenbrock_residuals,
@@ -427,7 +427,7 @@ mod ndarray_residuals_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_residuals_impl {
     use super::{RosenbrockResiduals, rosenbrock_residuals_jacobian};
     use crate::{CostFunction, Jacobian, Residual};
@@ -596,7 +596,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "nalgebra")]
+    #[cfg(feature = "nalgebra_all")]
     mod nalgebra_jacobian_tests {
         use super::super::RosenbrockResiduals;
         use crate::{
@@ -645,7 +645,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "faer")]
+    #[cfg(feature = "faer_all")]
     mod faer_jacobian_tests {
         use super::super::RosenbrockResiduals;
         use crate::{Jacobian, Residual};

--- a/crates/basin/src/problems/schaffer.rs
+++ b/crates/basin/src/problems/schaffer.rs
@@ -198,7 +198,7 @@ impl CostFunction for SchafferN4<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{
         SchafferN2, SchafferN4, schaffer_n2, schaffer_n2_gradient, schaffer_n4,
@@ -243,7 +243,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{
         SchafferN2, SchafferN4, schaffer_n2, schaffer_n2_gradient, schaffer_n4,
@@ -291,7 +291,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::{SchafferN2, SchafferN4};
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/problems/sparse_least_squares.rs
+++ b/crates/basin/src/problems/sparse_least_squares.rs
@@ -96,7 +96,7 @@ impl<M, V> HasSpec for SparseLeastSquaresBoxed<M, V> {
     const SPEC: &'static ProblemSpec = &SPARSE_LEAST_SQUARES_SPEC;
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{SparseLeastSquares, SparseLeastSquaresBoxed};
     use crate::core::math::{MatVec, ScaledAdd};
@@ -192,7 +192,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::{SparseLeastSquares, SparseLeastSquaresBoxed};
     use crate::core::math::{MatVec, ScaledAdd};
@@ -312,7 +312,7 @@ mod tests {
         assert!(!spec.references.is_empty());
     }
 
-    #[cfg(feature = "faer")]
+    #[cfg(feature = "faer_all")]
     #[test]
     fn faer_residual_at_zero_returns_minus_b() {
         use crate::Residual;

--- a/crates/basin/src/problems/sphere.rs
+++ b/crates/basin/src/problems/sphere.rs
@@ -100,7 +100,7 @@ impl Gradient for Sphere<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Sphere, sphere, sphere_gradient};
     use crate::{CostFunction, Gradient};
@@ -131,7 +131,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Sphere, sphere, sphere_gradient};
     use crate::{CostFunction, Gradient};
@@ -165,7 +165,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Sphere;
     use crate::{CostFunction, Gradient};
@@ -258,7 +258,7 @@ impl BoxConstraints for SphereBoxed<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_boxed_impl {
     use super::{STANDARD_LOWER, STANDARD_UPPER, SphereBoxed, sphere};
     use crate::{BoxConstraints, CostFunction};
@@ -297,7 +297,7 @@ mod nalgebra_boxed_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_boxed_impl {
     use super::{STANDARD_LOWER, STANDARD_UPPER, SphereBoxed, sphere};
     use crate::{BoxConstraints, CostFunction};
@@ -336,7 +336,7 @@ mod ndarray_boxed_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_boxed_impl {
     use super::{STANDARD_LOWER, STANDARD_UPPER, SphereBoxed};
     use crate::{BoxConstraints, CostFunction};

--- a/crates/basin/src/problems/step.rs
+++ b/crates/basin/src/problems/step.rs
@@ -85,7 +85,7 @@ impl CostFunction for Step<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Step, step};
     use crate::CostFunction;
@@ -104,7 +104,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Step, step};
     use crate::CostFunction;
@@ -123,7 +123,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Step;
     use crate::CostFunction;

--- a/crates/basin/src/problems/styblinski_tang.rs
+++ b/crates/basin/src/problems/styblinski_tang.rs
@@ -119,7 +119,7 @@ impl Gradient for StyblinskiTang<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{StyblinskiTang, styblinski_tang, styblinski_tang_gradient};
     use crate::{CostFunction, Gradient};
@@ -150,7 +150,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{StyblinskiTang, styblinski_tang, styblinski_tang_gradient};
     use crate::{CostFunction, Gradient};
@@ -184,7 +184,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::StyblinskiTang;
     use crate::{CostFunction, Gradient};
@@ -289,7 +289,7 @@ impl BoxConstraints for StyblinskiTangBoxed<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_boxed_impl {
     use super::{
         STANDARD_LOWER, STANDARD_UPPER, StyblinskiTangBoxed, styblinski_tang,
@@ -343,7 +343,7 @@ mod nalgebra_boxed_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_boxed_impl {
     use super::{
         STANDARD_LOWER, STANDARD_UPPER, StyblinskiTangBoxed, styblinski_tang,
@@ -400,7 +400,7 @@ mod ndarray_boxed_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_boxed_impl {
     use super::{STANDARD_LOWER, STANDARD_UPPER, StyblinskiTangBoxed};
     use crate::{BoxConstraints, CostFunction, Gradient};

--- a/crates/basin/src/problems/three_hump_camel.rs
+++ b/crates/basin/src/problems/three_hump_camel.rs
@@ -117,7 +117,7 @@ impl Gradient for ThreeHumpCamel<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{ThreeHumpCamel, three_hump_camel, three_hump_camel_gradient};
     use crate::{CostFunction, Gradient};
@@ -148,7 +148,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{ThreeHumpCamel, three_hump_camel, three_hump_camel_gradient};
     use crate::{CostFunction, Gradient};
@@ -184,7 +184,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::ThreeHumpCamel;
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/problems/zero.rs
+++ b/crates/basin/src/problems/zero.rs
@@ -99,7 +99,7 @@ impl Gradient for Zero<Vec<f64>> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra_impl {
     use super::{Zero, zero, zero_gradient};
     use crate::{CostFunction, Gradient};
@@ -130,7 +130,7 @@ mod nalgebra_impl {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 mod ndarray_impl {
     use super::{Zero, zero, zero_gradient};
     use crate::{CostFunction, Gradient};
@@ -164,7 +164,7 @@ mod ndarray_impl {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer_impl {
     use super::Zero;
     use crate::{CostFunction, Gradient};

--- a/crates/basin/src/solver/bfgs.rs
+++ b/crates/basin/src/solver/bfgs.rs
@@ -270,7 +270,7 @@ where
 
 impl<S, F> WarmStart<Vec<F>> for Bfgs<S, F> where F: Scalar {}
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 impl<S, F> InitialState<nalgebra::DVector<F>> for Bfgs<S, F>
 where
     F: Scalar + nalgebra::Scalar + num_traits::Zero,
@@ -284,13 +284,13 @@ where
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 impl<S, F> WarmStart<nalgebra::DVector<F>> for Bfgs<S, F> where
     F: Scalar + nalgebra::Scalar + num_traits::Zero
 {
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 impl<S, F> InitialState<faer::Col<F>> for Bfgs<S, F>
 where
     F: Scalar + faer_traits::ComplexField,
@@ -301,13 +301,13 @@ where
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 impl<S, F> WarmStart<faer::Col<F>> for Bfgs<S, F> where
     F: Scalar + faer_traits::ComplexField
 {
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 impl<S, F> InitialState<ndarray::Array1<F>> for Bfgs<S, F>
 where
     F: Scalar,
@@ -320,5 +320,5 @@ where
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 impl<S, F> WarmStart<ndarray::Array1<F>> for Bfgs<S, F> where F: Scalar {}

--- a/crates/basin/src/solver/lbfgs/backend.rs
+++ b/crates/basin/src/solver/lbfgs/backend.rs
@@ -35,20 +35,20 @@ impl<F> AsFloatSliceMut<F> for Vec<F> {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 impl<F: nalgebra::Scalar> AsFloatSlice<F> for nalgebra::DVector<F> {
     fn as_float_slice(&self) -> &[F] {
         self.as_slice()
     }
 }
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 impl<F: nalgebra::Scalar> AsFloatSliceMut<F> for nalgebra::DVector<F> {
     fn as_float_slice_mut(&mut self) -> &mut [F] {
         self.as_mut_slice()
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 impl<F: faer_traits::ComplexField> AsFloatSlice<F> for faer::Col<F> {
     fn as_float_slice(&self) -> &[F] {
         self.try_as_col_major()
@@ -56,7 +56,7 @@ impl<F: faer_traits::ComplexField> AsFloatSlice<F> for faer::Col<F> {
             .as_slice()
     }
 }
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 impl<F: faer_traits::ComplexField> AsFloatSliceMut<F> for faer::Col<F> {
     fn as_float_slice_mut(&mut self) -> &mut [F] {
         self.try_as_col_major_mut()
@@ -65,13 +65,13 @@ impl<F: faer_traits::ComplexField> AsFloatSliceMut<F> for faer::Col<F> {
     }
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 impl<F> AsFloatSlice<F> for ndarray::Array1<F> {
     fn as_float_slice(&self) -> &[F] {
         self.as_slice().expect("Array1 is contiguous")
     }
 }
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 impl<F> AsFloatSliceMut<F> for ndarray::Array1<F> {
     fn as_float_slice_mut(&mut self) -> &mut [F] {
         self.as_slice_mut().expect("Array1 is contiguous")

--- a/crates/basin/src/solver/levenberg_marquardt.rs
+++ b/crates/basin/src/solver/levenberg_marquardt.rs
@@ -168,7 +168,7 @@ use crate::core::termination::TerminationReason;
 /// and runs on the matrix-capable backends:
 ///
 /// ```
-/// # #[cfg(feature = "nalgebra")] {
+/// # #[cfg(feature = "nalgebra_v0_35")] {
 /// use basin::{NllsState, Executor, Jacobian, LevenbergMarquardt, Residual};
 /// use nalgebra::{DMatrix, DVector};
 ///

--- a/crates/basin/src/solver/trust_region.rs
+++ b/crates/basin/src/solver/trust_region.rs
@@ -348,7 +348,7 @@ where
 /// Hessian uses):
 ///
 /// ```
-/// # #[cfg(feature = "nalgebra")] {
+/// # #[cfg(feature = "nalgebra_v0_35")] {
 /// use basin::{CostFunction, Executor, Gradient, GradientTolerance, Hessian, TrustRegion};
 /// use nalgebra::{DMatrix, DVector};
 ///

--- a/crates/basin/src/solver/trust_region/more_sorensen.rs
+++ b/crates/basin/src/solver/trust_region/more_sorensen.rs
@@ -569,7 +569,7 @@ mod tests {
         assert!(!step.hit_boundary);
     }
 
-    #[cfg(feature = "nalgebra")]
+    #[cfg(feature = "nalgebra_all")]
     #[test]
     fn hard_case_runs_on_nalgebra() {
         use nalgebra::{DMatrix, DVector};
@@ -582,7 +582,7 @@ mod tests {
         assert_close(step.d[1], -0.5, 1e-10);
     }
 
-    #[cfg(feature = "ndarray")]
+    #[cfg(feature = "ndarray_all")]
     #[test]
     fn hard_case_runs_on_ndarray() {
         use ndarray::{Array1, Array2};
@@ -597,7 +597,7 @@ mod tests {
         assert_close(step.d[1], -0.5, 1e-10);
     }
 
-    #[cfg(feature = "faer")]
+    #[cfg(feature = "faer_all")]
     #[test]
     fn hard_case_runs_on_faer() {
         use faer::{Col, Mat};

--- a/crates/basin/tests/augmented_lagrangian_faer.rs
+++ b/crates/basin/tests/augmented_lagrangian_faer.rs
@@ -1,13 +1,13 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 //! Integration tests for the augmented-Lagrangian [`AugmentedLagrangianMethod`]
 //! on linearly-equality-constrained quadratics (faer backend).
 
+use crate::backend_aliases::faer::{Col, Mat};
 use basin::problems::EqualityConstrainedQuadratic;
 use basin::{
     AugmentedLagrangianMethod, Backtracking, BasicState, Executor,
     GradientDescent, GradientState, TerminationReason,
 };
-use faer::{Col, Mat};
 
 /// `min ‖x − (2,2)‖²` s.t. `x₀ + x₁ = 2`. Constrained optimum: the
 /// projection of (2,2) onto the line `x₀ + x₁ = 2`, namely (1,1).
@@ -98,3 +98,6 @@ fn eval_counts_are_recorded() {
         "no gradient evals recorded"
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/augmented_lagrangian_nalgebra.rs
+++ b/crates/basin/tests/augmented_lagrangian_nalgebra.rs
@@ -1,13 +1,13 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 //! Integration tests for the augmented-Lagrangian [`AugmentedLagrangianMethod`]
 //! on linearly-equality-constrained quadratics (nalgebra backend).
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::EqualityConstrainedQuadratic;
 use basin::{
     AugmentedLagrangianMethod, Backtracking, BasicState, Bfgs, Executor,
     GradientDescent, GradientState, Lbfgsb, TerminationReason,
 };
-use nalgebra::{DMatrix, DVector};
 
 /// `min ‖x − (2,2)‖²` s.t. `x₀ + x₁ = 2`. The unconstrained min (2,2) is
 /// infeasible (sum 4 ≠ 2); the constrained optimum is the projection of
@@ -156,3 +156,6 @@ fn lbfgs_inner_converges_to_affine_projection() {
         result.param()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/augmented_lagrangian_ndarray.rs
+++ b/crates/basin/tests/augmented_lagrangian_ndarray.rs
@@ -1,14 +1,14 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 //! Integration tests for the augmented-Lagrangian [`AugmentedLagrangianMethod`]
 //! on linearly-equality-constrained quadratics (ndarray backend). Exercises the
 //! `MatVec`/`MatTransposeVec` impls on `ndarray::Array2<f64>`.
 
+use crate::backend_aliases::ndarray::{Array1, Array2, array};
 use basin::problems::EqualityConstrainedQuadratic;
 use basin::{
     AugmentedLagrangianMethod, Backtracking, BasicState, Executor,
     GradientDescent, GradientState, TerminationReason,
 };
-use ndarray::{Array1, Array2, array};
 
 /// `min ‖x − (2,2)‖²` s.t. `x₀ + x₁ = 2`; constrained optimum (1,1).
 fn single_row_problem() -> EqualityConstrainedQuadratic<Array2<f64>, Array1<f64>>
@@ -97,3 +97,6 @@ fn eval_counts_are_recorded() {
         "no gradient evals recorded"
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/barrier_method_faer.rs
+++ b/crates/basin/tests/barrier_method_faer.rs
@@ -1,14 +1,14 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 //! Integration tests for the log-barrier [`BarrierMethod`] on linearly
 //! constrained quadratics (faer backend), mirror of
 //! `barrier_method_nalgebra.rs`.
 
+use crate::backend_aliases::faer::{Col, Mat};
 use basin::problems::ConstrainedQuadratic;
 use basin::{
     Backtracking, BarrierMethod, BasicState, Executor, GradientDescent,
     GradientState, TerminationReason,
 };
-use faer::{Col, Mat};
 
 /// `min ‖x − (2,2)‖²` s.t. `x₀ + x₁ ≤ 2`; constrained optimum (1, 1).
 fn active_problem() -> ConstrainedQuadratic<Mat<f64>, Col<f64>> {
@@ -125,3 +125,6 @@ fn eval_counts_are_recorded() {
         "no gradient evals recorded"
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/barrier_method_nalgebra.rs
+++ b/crates/basin/tests/barrier_method_nalgebra.rs
@@ -1,13 +1,13 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 //! Integration tests for the log-barrier [`BarrierMethod`] on linearly
 //! constrained quadratics (nalgebra backend).
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::ConstrainedQuadratic;
 use basin::{
     Backtracking, BarrierMethod, BasicState, Bfgs, Executor, GradientDescent,
     GradientState, TerminationReason,
 };
-use nalgebra::{DMatrix, DVector};
 
 /// `min ‖x − (2,2)‖²` s.t. `x₀ + x₁ ≤ 2`. The unconstrained min (2,2) is
 /// infeasible; the constrained optimum is the projection (1,1).
@@ -186,3 +186,6 @@ fn bfgs_inner_converges_to_projection() {
         result.param()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/barrier_method_ndarray.rs
+++ b/crates/basin/tests/barrier_method_ndarray.rs
@@ -1,14 +1,14 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 //! Integration tests for the log-barrier [`BarrierMethod`] on linearly
 //! constrained quadratics (ndarray backend). Exercises the
 //! `MatVec`/`MatTransposeVec` impls on `ndarray::Array2<f64>`.
 
+use crate::backend_aliases::ndarray::{Array1, Array2, array};
 use basin::problems::ConstrainedQuadratic;
 use basin::{
     Backtracking, BarrierMethod, BasicState, Executor, GradientDescent,
     GradientState, TerminationReason,
 };
-use ndarray::{Array1, Array2, array};
 
 /// `min ‖x − (2,2)‖²` s.t. `x₀ + x₁ ≤ 2`; constrained optimum (1,1).
 fn active_problem() -> ConstrainedQuadratic<Array2<f64>, Array1<f64>> {
@@ -118,3 +118,6 @@ fn two_constraints_both_active() {
         result.param()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/bfgs.rs
+++ b/crates/basin/tests/bfgs.rs
@@ -1,12 +1,12 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::Rosenbrock;
 use basin::{
     Backtracking, BasicState, Bfgs, CostFunction, Executor, Gradient,
     GradientDescent, GradientTolerance, NalgebraQuasiNewtonState,
     TerminationReason,
 };
-use nalgebra::DVector;
 
 #[test]
 fn bfgs_converges_on_rosenbrock() {
@@ -38,6 +38,9 @@ fn bfgs_converges_on_rosenbrock() {
         result.param()[1]
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;
 
 #[test]
 fn bfgs_terminates_on_gradient_tolerance() {

--- a/crates/basin/tests/bfgs_faer.rs
+++ b/crates/basin/tests/bfgs_faer.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
 //! Bfgs convergence over the faer backend (`Col<f64>` and `Mat<f64>`).
 //!
@@ -6,11 +6,11 @@
 //! the same generic `Solver` impl drives faer's dense inverse-Hessian via
 //! `MatVec` + `GeneralRankOneUpdate` on `Mat<f64>`.
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::Rosenbrock;
 use basin::{
     Bfgs, Executor, FaerQuasiNewtonState, GradientTolerance, TerminationReason,
 };
-use faer::Col;
 
 #[test]
 fn bfgs_converges_on_rosenbrock() {
@@ -55,3 +55,6 @@ fn bfgs_terminates_on_gradient_tolerance() {
     assert_eq!(result.reason, TerminationReason::GradientTolerance);
     assert!(result.cost() < 1e-10, "cost = {}", result.cost());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/bfgs_ndarray.rs
+++ b/crates/basin/tests/bfgs_ndarray.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
 //! Bfgs convergence over the ndarray backend (`Array1<f64>` and `Array2<f64>`).
 //!
@@ -7,16 +7,17 @@
 //! ndarray's dense inverse-Hessian via `MatVec` + `GeneralRankOneUpdate` on
 //! `Array2<f64>`.
 
+use crate::backend_aliases::ndarray::array;
 use basin::problems::Rosenbrock;
 use basin::{
     Bfgs, Executor, GradientTolerance, NdarrayQuasiNewtonState,
     TerminationReason,
 };
-use ndarray::array;
 
 #[test]
 fn bfgs_converges_on_rosenbrock() {
-    let problem = Rosenbrock::<ndarray::Array1<f64>>::default();
+    let problem =
+        Rosenbrock::<crate::backend_aliases::ndarray::Array1<f64>>::default();
     let initial = array![-1.2, 1.0];
 
     let result = Executor::new(
@@ -47,7 +48,8 @@ fn bfgs_converges_on_rosenbrock() {
 
 #[test]
 fn bfgs_terminates_on_gradient_tolerance() {
-    let problem = Rosenbrock::<ndarray::Array1<f64>>::default();
+    let problem =
+        Rosenbrock::<crate::backend_aliases::ndarray::Array1<f64>>::default();
     let initial = array![-1.2, 1.0];
 
     let result = Executor::new(
@@ -63,3 +65,6 @@ fn bfgs_terminates_on_gradient_tolerance() {
     assert_eq!(result.reason, TerminationReason::GradientTolerance);
     assert!(result.cost() < 1e-10, "cost = {}", result.cost());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/bounded_cma_es_faer.rs
+++ b/crates/basin/tests/bounded_cma_es_faer.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::{Col, Mat};
 use basin::problems::BoothBoxed;
 use basin::{
     BoundedCmaEs, CmaEsState, CmaEsTolerance, Executor, PopulationState,
     StepOutcome, TerminationReason,
 };
-use faer::{Col, Mat};
 
 /// Same seed → same trajectory on the faer backend's bounded variant.
 /// Same-backend reproducibility is the load-bearing contract; the
@@ -170,3 +170,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/bounded_cma_es_nalgebra.rs
+++ b/crates/basin/tests/bounded_cma_es_nalgebra.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::BoothBoxed;
 use basin::{
     BoundedCmaEs, CmaEsState, CmaEsTolerance, Executor, PopulationState,
     StepOutcome, TerminationReason,
 };
-use nalgebra::{DMatrix, DVector};
 
 /// Same seed → same trajectory on the bounded variant. Reproducibility
 /// is the load-bearing contract for the seeded RNG; this guards the
@@ -248,3 +248,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/bounded_cma_es_ndarray.rs
+++ b/crates/basin/tests/bounded_cma_es_ndarray.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
+use crate::backend_aliases::ndarray::{Array1, Array2};
 use basin::problems::BoothBoxed;
 use basin::{
     BoundedCmaEs, CmaEsState, CmaEsTolerance, Executor, PopulationState,
     StepOutcome, TerminationReason,
 };
-use ndarray::{Array1, Array2};
 
 /// Same seed → same trajectory on the bounded variant. Reproducibility
 /// is the load-bearing contract for the seeded RNG; this guards the
@@ -247,3 +247,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/bounded_cma_inject_lbfgsb_faer.rs
+++ b/crates/basin/tests/bounded_cma_inject_lbfgsb_faer.rs
@@ -5,11 +5,11 @@
 //! by the nalgebra mirror test
 //! (`tests/bounded_cma_inject_lbfgsb_nalgebra.rs`).
 
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::{Col, Mat};
 use basin::problems::BoothBoxed;
 use basin::{BoundedCmaEs, BoundedCmaInject, CmaEsState, Executor, Lbfgsb};
-use faer::{Col, Mat};
 
 /// BoundedCmaEs + L-Bfgs-B on Booth with slack bounds `[-5, 5]²`; the
 /// global min `(1, 3)` is strictly interior, so the inner polish must
@@ -96,3 +96,6 @@ fn aggregates_lbfgsb_work_into_outer() {
         min_extra
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/bounded_cma_inject_lbfgsb_nalgebra.rs
+++ b/crates/basin/tests/bounded_cma_inject_lbfgsb_nalgebra.rs
@@ -6,11 +6,11 @@
 //! and work-unit aggregation (L-Bfgs-B `cost_evals` + `gradient_evals`
 //! roll into the outer's `cost_evals`).
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::BoothBoxed;
 use basin::{BoundedCmaEs, BoundedCmaInject, CmaEsState, Executor, Lbfgsb};
-use nalgebra::{DMatrix, DVector};
 
 /// BoundedCmaEs + L-Bfgs-B on Booth with slack bounds `[-5, 5]²`. The
 /// global min `(1, 3)` is strictly interior, so both the outer
@@ -117,3 +117,6 @@ fn aggregates_lbfgsb_work_into_outer() {
         min_extra
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/bounded_cma_inject_lbfgsb_ndarray.rs
+++ b/crates/basin/tests/bounded_cma_inject_lbfgsb_ndarray.rs
@@ -5,11 +5,11 @@
 //! are covered by the nalgebra mirror test
 //! (`tests/bounded_cma_inject_lbfgsb_nalgebra.rs`).
 
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
+use crate::backend_aliases::ndarray::{Array1, Array2};
 use basin::problems::BoothBoxed;
 use basin::{BoundedCmaEs, BoundedCmaInject, CmaEsState, Executor, Lbfgsb};
-use ndarray::{Array1, Array2};
 
 /// BoundedCmaEs + L-Bfgs-B on Booth with slack bounds `[-5, 5]²`; the
 /// global min `(1, 3)` is strictly interior, so the inner polish must
@@ -96,3 +96,6 @@ fn aggregates_lbfgsb_work_into_outer() {
         min_extra
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cma_es_faer.rs
+++ b/crates/basin/tests/cma_es_faer.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::{Col, Mat};
 use basin::problems::{Rosenbrock, Sphere};
 use basin::{
     CmaEs, CmaEsState, CmaEsTolerance, Executor, PopulationState, StepOutcome,
     TerminationReason,
 };
-use faer::{Col, Mat};
 
 /// Same seed → same trajectory, on the faer backend. Reproducibility
 /// across faer's `Col<f64>` and `Mat<f64>` types is independent of the
@@ -190,3 +190,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cma_es_nalgebra.rs
+++ b/crates/basin/tests/cma_es_nalgebra.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::{Rosenbrock, Sphere};
 use basin::{
     CmaEs, CmaEsState, CmaEsTolerance, CostFunction, Executor, PopulationState,
     StepOutcome, TerminationReason,
 };
-use nalgebra::{DMatrix, DVector};
 
 /// Same seed → same trajectory, on the nalgebra backend. Reproducibility
 /// is the load-bearing contract for the seeded RNG (per
@@ -276,3 +276,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cma_es_ndarray.rs
+++ b/crates/basin/tests/cma_es_ndarray.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
+use crate::backend_aliases::ndarray::{Array1, Array2};
 use basin::problems::{Rosenbrock, Sphere};
 use basin::{
     CmaEs, CmaEsState, CmaEsTolerance, CostFunction, Executor, PopulationState,
     StepOutcome, TerminationReason,
 };
-use ndarray::{Array1, Array2};
 
 /// Same seed → same trajectory, on the ndarray backend. Reproducibility
 /// is the load-bearing contract for the seeded RNG (per
@@ -276,3 +276,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cma_inject_faer.rs
+++ b/crates/basin/tests/cma_inject_faer.rs
@@ -4,11 +4,11 @@
 //! boundary; the deeper algorithmic invariants are covered by the
 //! nalgebra mirror test (`tests/cma_inject_nalgebra.rs`).
 
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::{Col, Mat};
 use basin::problems::{Rosenbrock, Sphere};
 use basin::{CmaEs, CmaEsState, CmaInject, Executor, NelderMead};
-use faer::{Col, Mat};
 
 /// Rosenbrock 2-D from `(-1, 1)`: injecting Nelder-Mead refinements
 /// must not break CMA's convergence on the faer backend.
@@ -86,3 +86,6 @@ fn aggregates_inner_cost_evals_into_outer() {
         min_extra
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cma_inject_lm_nalgebra.rs
+++ b/crates/basin/tests/cma_inject_lm_nalgebra.rs
@@ -6,11 +6,11 @@
 //! precision) and work-unit aggregation (LM `cost_evals` +
 //! `gradient_evals` roll into the outer's `cost_evals`).
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::RosenbrockResiduals;
 use basin::{CmaEs, CmaEsState, CmaInject, Executor, LevenbergMarquardt};
-use nalgebra::{DMatrix, DVector};
 
 /// CMA-ES + LM on 2-D Rosenbrock-as-residuals. CMA from a wide-σ start
 /// gets near `(1, 1)`; the inner LM (Nielsen damping, default tolerances)
@@ -104,3 +104,6 @@ fn aggregates_lm_work_into_outer() {
         min_extra
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cma_inject_nalgebra.rs
+++ b/crates/basin/tests/cma_inject_nalgebra.rs
@@ -11,11 +11,11 @@
 //! `SolverFailed`-bubbling contract test (CONTRIBUTING.md "Solver composition"
 //! rule 3) see `cma_inject_solver_failed_bubbles.rs`.
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::{Rosenbrock, Sphere};
 use basin::{CmaEs, CmaEsState, CmaInject, Executor, NelderMead};
-use nalgebra::{DMatrix, DVector};
 
 /// Rosenbrock 2-D from `(-1, 1)`: the canonical non-convex banana
 /// valley CMA-ES is famously good at. The point of this test is to
@@ -118,3 +118,6 @@ fn aggregates_inner_cost_evals_into_outer() {
         min_extra
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cma_inject_ndarray.rs
+++ b/crates/basin/tests/cma_inject_ndarray.rs
@@ -6,11 +6,11 @@
 //! invariants are covered by the nalgebra mirror test
 //! (`tests/cma_inject_nalgebra.rs`).
 
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
+use crate::backend_aliases::ndarray::{Array1, Array2};
 use basin::problems::{Rosenbrock, Sphere};
 use basin::{CmaEs, CmaEsState, CmaInject, Executor, NelderMead};
-use ndarray::{Array1, Array2};
 
 /// Rosenbrock 2-D from `(-1, 1)`: injecting Nelder-Mead refinements
 /// must not break CMA's convergence on the ndarray backend.
@@ -88,3 +88,6 @@ fn aggregates_inner_cost_evals_into_outer() {
         min_extra
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cma_inject_solver_failed_bubbles.rs
+++ b/crates/basin/tests/cma_inject_solver_failed_bubbles.rs
@@ -9,14 +9,14 @@
 //! deferred test promoted to a real fixture (S11 hardwired NelderMead
 //! and NelderMead never returns `SolverFailed`).
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::Sphere;
 use basin::{
     BasicState, ClosureInner, CmaEs, CmaEsState, CmaInject, Executor, Problem,
     Solver, State, TerminationReason,
 };
-use nalgebra::{DMatrix, DVector};
 
 /// Inner solver that always returns `SolverFailed` on the first
 /// `next_iter` call. Same shape as the `AlwaysFails` in
@@ -68,3 +68,6 @@ fn bubbles_inner_failure() {
     // so iter == 0.
     assert_eq!(result.iter(), 0, "expected iter = 0 (mid-iter bail)");
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/cobyla_public.rs
+++ b/crates/basin/tests/cobyla_public.rs
@@ -108,10 +108,10 @@ fn rho_tolerance_stops_early() {
 /// Backend-generic: drive COBYLA on nalgebra `DVector`. Guards the
 /// support-matrix ✓ for nalgebra; the param vector must satisfy
 /// `VectorLen + Index + IndexMut`.
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 #[test]
 fn backend_generic_nalgebra() {
-    use nalgebra::DVector;
+    use crate::backend_aliases::nalgebra::DVector;
 
     struct Disk;
     impl CostFunction for Disk {
@@ -158,10 +158,10 @@ fn backend_generic_nalgebra() {
 
 /// Backend-generic: drive COBYLA on ndarray `Array1`. Guards the
 /// support-matrix ✓ for ndarray.
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 #[test]
 fn backend_generic_ndarray() {
-    use ndarray::Array1;
+    use crate::backend_aliases::ndarray::Array1;
 
     struct Disk;
     impl CostFunction for Disk {
@@ -208,10 +208,10 @@ fn backend_generic_ndarray() {
 
 /// Backend-generic: drive COBYLA on faer `Col`. Guards the support-matrix ✓ for
 /// faer.
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 #[test]
 fn backend_generic_faer() {
-    use faer::Col;
+    use crate::backend_aliases::faer::Col;
 
     struct Disk;
     impl CostFunction for Disk {
@@ -253,3 +253,6 @@ fn backend_generic_faer() {
     let x = result.best_param();
     assert!(x[0] * x[0] + x[1] * x[1] <= 1.0 + 1e-6, "infeasible {x:?}");
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/de_inject_lbfgsb_nalgebra.rs
+++ b/crates/basin/tests/de_inject_lbfgsb_nalgebra.rs
@@ -6,11 +6,11 @@
 //! in the basin within a handful of generations; L-Bfgs-B drives them
 //! to gradient-descent precision. Assert `‖x* − (1, 3)‖_∞ ≤ 1e-6`.
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::BoothBoxed;
 use basin::{BasicPopulationState, De, DeInject, Executor, Lbfgsb};
-use nalgebra::DVector;
 
 #[test]
 fn converges_on_booth_boxed_to_lbfgsb_precision() {
@@ -42,3 +42,6 @@ fn converges_on_booth_boxed_to_lbfgsb_precision() {
         err
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/de_inject_nalgebra.rs
+++ b/crates/basin/tests/de_inject_nalgebra.rs
@@ -9,13 +9,13 @@
 //! `de_inject_lbfgsb_nalgebra.rs`; for the failure-bubbling contract
 //! test (rule 3) see `de_inject_solver_failed_bubbles.rs`.
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::{AckleyBoxed, RastriginBoxed};
 use basin::{
     BasicPopulationState, De, DeInject, Executor, MaxCostEvals, NelderMead,
 };
-use nalgebra::DVector;
 
 /// Ackley D=3 within the standard `[-32.768, 32.768]³` box. Ackley's
 /// exponential-decay global basin is friendly to Nelder-Mead polish:
@@ -148,3 +148,6 @@ fn same_seed_yields_identical_trajectory() {
     assert_eq!(result_a.cost(), result_b.cost());
     assert_eq!(result_a.param(), result_b.param());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/de_inject_solver_failed_bubbles.rs
+++ b/crates/basin/tests/de_inject_solver_failed_bubbles.rs
@@ -5,14 +5,14 @@
 //! Mirror of `cma_inject_solver_failed_bubbles.rs`: same
 //! `AlwaysFails` fixture wrapped in [`ClosureInner`] for the seeder.
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::RastriginBoxed;
 use basin::{
     BasicPopulationState, BasicState, ClosureInner, De, DeInject, Executor,
     Problem, Solver, State, TerminationReason,
 };
-use nalgebra::DVector;
 
 /// Inner solver that always returns `SolverFailed` on the first
 /// `next_iter` call. Same shape as the `AlwaysFails` in
@@ -62,3 +62,6 @@ fn bubbles_inner_failure() {
     // so iter == 0.
     assert_eq!(result.iter(), 0, "expected iter = 0 (mid-iter bail)");
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/example_bounded_cma_inject_lm.rs
+++ b/crates/basin/tests/example_bounded_cma_inject_lm.rs
@@ -13,13 +13,13 @@
 //! nalgebra -- --nocapture`. The `--nocapture` flag is what lets the
 //! progress prints land in your terminal.
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::BoothBoxedResiduals;
 use basin::{
     BoundedCmaEs, BoundedCmaInject, CmaEsState, Executor, LevenbergMarquardt,
 };
-use nalgebra::{DMatrix, DVector};
 
 #[test]
 fn example_bounded_cma_inject_lm_on_booth_corner() {
@@ -104,3 +104,6 @@ fn example_bounded_cma_inject_lm_on_booth_corner() {
         err
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/from_start_round_trip.rs
+++ b/crates/basin/tests/from_start_round_trip.rs
@@ -256,10 +256,10 @@ fn mads_state() {
 /// the nalgebra and faer seed impls added alongside it (`WarmStart` was
 /// nalgebra-only before). `ndarray` is intentionally absent: BFGS does not
 /// run on `Array2` (no `GeneralRankOneUpdate`).
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 #[test]
 fn bfgs_from_start_nalgebra_backend() {
-    use nalgebra::DVector;
+    use crate::backend_aliases::nalgebra::DVector;
 
     struct QuadN;
     impl CostFunction for QuadN {
@@ -302,10 +302,10 @@ fn bfgs_from_start_nalgebra_backend() {
     assert!(a.cost() < 1e-12);
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 #[test]
 fn bfgs_from_start_faer_backend() {
-    use faer::Col;
+    use crate::backend_aliases::faer::Col;
 
     struct QuadF;
     impl CostFunction for QuadF {
@@ -391,3 +391,6 @@ fn from_start_round_trips_at_f32() {
     assert_eq!(a.param(), b.param());
     assert_eq!(a.cost(), b.cost());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/fused_problem.rs
+++ b/crates/basin/tests/fused_problem.rs
@@ -130,11 +130,11 @@ fn solver_calls_fused_override() {
 // 3. CostAndGradientAndHessian: defaulted body equals separate calls.
 // ---------------------------------------------------------------------
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod hessian {
     use super::*;
+    use crate::backend_aliases::nalgebra::{DMatrix, DVector};
     use basin::Hessian;
-    use nalgebra::{DMatrix, DVector};
 
     struct SphereN;
     impl CostFunction for SphereN {
@@ -242,11 +242,11 @@ mod hessian {
 // 4. ResidualAndJacobian: LM actually calls the fused override.
 // ---------------------------------------------------------------------
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod lsq {
     use super::*;
+    use crate::backend_aliases::nalgebra::{DMatrix, DVector};
     use basin::{Jacobian, LevenbergMarquardt, NllsState, Residual};
-    use nalgebra::{DMatrix, DVector};
 
     /// `r(x) = (x₀ − 1, x₁ − 2)`, J = I. Minimum at (1, 2).
     struct Affine {
@@ -349,3 +349,6 @@ fn finite_diff_runs_through_solver() {
     assert!((x[0] - 1.0).abs() < 1e-3);
     assert!((x[1] - 1.0).abs() < 1e-3);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/gauss_newton_faer.rs
+++ b/crates/basin/tests/gauss_newton_faer.rs
@@ -1,8 +1,8 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::{PowellSingular, RosenbrockResiduals};
 use basin::{Executor, GaussNewton, NllsState, TerminationReason};
-use faer::Col;
 
 #[test]
 fn gauss_newton_converges_on_rosenbrock_residuals() {
@@ -91,3 +91,6 @@ fn gauss_newton_fails_on_rank_deficient_powell_singular_jacobian() {
 
     assert_eq!(result.reason, TerminationReason::SolverFailed);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/gauss_newton_faer_sparse.rs
+++ b/crates/basin/tests/gauss_newton_faer_sparse.rs
@@ -1,9 +1,9 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
+use crate::backend_aliases::faer::sparse::{SparseColMat, Triplet};
 use basin::problems::SparseLeastSquares;
 use basin::{Executor, GaussNewton, NllsState, TerminationReason};
-use faer::Col;
-use faer::sparse::{SparseColMat, Triplet};
 
 type FaerSparseLeastSquares =
     SparseLeastSquares<SparseColMat<usize, f64>, Col<f64>>;
@@ -105,3 +105,6 @@ fn gauss_newton_emits_solver_converged_via_first_order_optimality() {
             .unwrap();
     assert_eq!(result.reason, TerminationReason::SolverConverged);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/gauss_newton_nalgebra.rs
+++ b/crates/basin/tests/gauss_newton_nalgebra.rs
@@ -1,8 +1,8 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::{PowellSingular, RosenbrockResiduals};
 use basin::{Executor, GaussNewton, NllsState, TerminationReason};
-use nalgebra::DVector;
 
 #[test]
 fn gauss_newton_converges_on_rosenbrock_residuals() {
@@ -144,3 +144,6 @@ fn gauss_newton_caches_residual_and_jacobian_across_iterations() {
          (3 total)"
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/gauss_newton_nalgebra_sparse.rs
+++ b/crates/basin/tests/gauss_newton_nalgebra_sparse.rs
@@ -1,9 +1,9 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
+use crate::backend_aliases::nalgebra_sparse::{CooMatrix, CscMatrix};
 use basin::problems::SparseLeastSquares;
 use basin::{Executor, GaussNewton, NllsState, TerminationReason};
-use nalgebra::DVector;
-use nalgebra_sparse::{CooMatrix, CscMatrix};
 
 /// 6×3 sparse design with `b = A·[1,2,3]` so the closed-form
 /// least-squares minimum has zero residual at `x* = [1, 2, 3]`.
@@ -100,3 +100,6 @@ fn gauss_newton_emits_solver_converged_via_first_order_optimality() {
             .unwrap();
     assert_eq!(result.reason, TerminationReason::SolverConverged);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/gauss_newton_ndarray.rs
+++ b/crates/basin/tests/gauss_newton_ndarray.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
 //! Gauss-Newton over the `ndarray` backend (`Array1<f64>`/`Array2<f64>`).
 //!
@@ -8,9 +8,9 @@
 //! and the rank-deficient failure are backend-independent; the assertions
 //! match the nalgebra mirror exactly.
 
+use crate::backend_aliases::ndarray::Array1;
 use basin::problems::{PowellSingular, RosenbrockResiduals};
 use basin::{Executor, GaussNewton, NllsState, TerminationReason};
-use ndarray::Array1;
 
 #[test]
 fn gauss_newton_converges_on_rosenbrock_residuals() {
@@ -152,3 +152,6 @@ fn gauss_newton_caches_residual_and_jacobian_across_iterations() {
          (3 total)"
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/lapack_nalgebra.rs
+++ b/crates/basin/tests/lapack_nalgebra.rs
@@ -1,23 +1,31 @@
-//! LAPACK-backed nalgebra factorizations (`nalgebra-lapack` feature).
+//! LAPACK-backed nalgebra factorizations (the versioned `*-lapack` features).
 //!
-//! These exercise the `#[cfg(feature = "nalgebra-lapack")]` impls in
-//! `core::math::nalgebra_backend` (LAPACK Cholesky for `LinearSolveSpd`, LAPACK
-//! `dsyev` for `SymmetricEigen`), mirroring the pure-Rust unit tests in that
-//! module so both code paths are checked against the same expectations.
+//! These exercise the LAPACK-selected impls in `core::math::nalgebra_backend`
+//! (LAPACK Cholesky for `LinearSolveSpd` and `dsyev` for `SymmetricEigen`),
+//! mirroring the pure-Rust unit tests in that module so both code paths are
+//! checked against the same expectations.
 //!
 //! Running this test *links* LAPACK, so it needs a provider supplied at link
-//! time (basin's `nalgebra-lapack` feature uses `lapack-custom`). CI installs a
-//! system OpenBLAS and links it via `RUSTFLAGS`; see `.github/workflows/ci.yml`.
+//! time. CI installs a system OpenBLAS and links it via `RUSTFLAGS`; see
+//! `.github/workflows/ci.yml`.
 //! Locally (devenv exposes an LP64 OpenBLAS as `$OPENBLAS_LP64_LIB`):
 //!
 //! ```sh
 //! RUSTFLAGS="-L $OPENBLAS_LP64_LIB -l openblas" \
-//!   cargo test -p basin --features nalgebra-lapack --test lapack_nalgebra
+//!   cargo test -p basin --features nalgebra_latest-lapack --test lapack_nalgebra
 //! ```
-#![cfg(all(feature = "nalgebra", feature = "nalgebra-lapack"))]
+#![cfg(all(
+    feature = "nalgebra_all",
+    any(
+        feature = "nalgebra_v0_32-lapack",
+        feature = "nalgebra_v0_33-lapack",
+        feature = "nalgebra_v0_34-lapack",
+        feature = "nalgebra_v0_35-lapack"
+    )
+))]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::{GramMatrix, LinearSolveError, LinearSolveSpd, SymmetricEigen};
-use nalgebra::{DMatrix, DVector};
 
 fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
     (a - b).abs() < tol
@@ -92,3 +100,6 @@ fn gauss_newton_converges_through_lapack_cholesky() {
     assert!(approx_eq(x[0], 1.0, 1e-6));
     assert!(approx_eq(x[1], 1.0, 1e-6));
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/lbfgs_unbounded.rs
+++ b/crates/basin/tests/lbfgs_unbounded.rs
@@ -64,10 +64,10 @@ fn rosenbrock_vec() {
     );
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 #[test]
 fn rosenbrock_nalgebra() {
-    use nalgebra::DVector;
+    use crate::backend_aliases::nalgebra::DVector;
 
     struct Rosen;
     impl CostFunction for Rosen {
@@ -110,10 +110,10 @@ fn rosenbrock_nalgebra() {
     );
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 #[test]
 fn rosenbrock_faer() {
-    use faer::Col;
+    use crate::backend_aliases::faer::Col;
 
     struct Rosen;
     impl CostFunction for Rosen {
@@ -154,10 +154,10 @@ fn rosenbrock_faer() {
     );
 }
 
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 #[test]
 fn rosenbrock_ndarray() {
-    use ndarray::{Array1, array};
+    use crate::backend_aliases::ndarray::{Array1, array};
 
     struct Rosen;
     impl CostFunction for Rosen {
@@ -211,3 +211,6 @@ fn lbfgsb_alias_compiles() {
     // default line search (MoreThuente); same identity as above.
     let _: Lbfgsb = Lbfgs::default();
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/lbfgsb_faer.rs
+++ b/crates/basin/tests/lbfgsb_faer.rs
@@ -1,15 +1,15 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
 //! L-Bfgs-B convergence tests over the faer backend. Mirrors
 //! `tests/lbfgsb_vec.rs` to confirm the `Col<f64>` impl of
 //! [`basin::backend::AsFloatSliceMut`] plumbs through correctly.
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::BoothBoxed;
 use basin::{
     BoxConstraints, CostFunction, Executor, Gradient, LbfgsState, Lbfgsb,
     MaxIter, ProjectedGradientTolerance,
 };
-use faer::Col;
 
 struct Rosen {
     l: Col<f64>,
@@ -130,3 +130,6 @@ fn booth_slack_bounds_recover_unconstrained_minimum() {
     );
     assert!(result.cost() < 1e-8, "cost = {}", result.cost());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/lbfgsb_nalgebra.rs
+++ b/crates/basin/tests/lbfgsb_nalgebra.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
 //! L-Bfgs-B convergence tests over the nalgebra backend.
 //!
@@ -6,12 +6,12 @@
 //! [`basin::backend::AsFloatSliceMut`]'s `DVector<f64>` impl plumbs
 //! through correctly and parity with the Vec backend holds.
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::BoothBoxed;
 use basin::{
     Bfgs, BoxConstraints, CostFunction, Executor, Gradient, LbfgsState, Lbfgsb,
     MaxIter, MoreThuente, NalgebraQuasiNewtonState, ProjectedGradientTolerance,
 };
-use nalgebra::DVector;
 
 struct Rosen {
     l: DVector<f64>,
@@ -185,3 +185,6 @@ fn lbfgsb_matches_bfgs_more_thuente_on_unbounded_rosenbrock() {
         bfgs_result.iter()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/lbfgsb_ndarray.rs
+++ b/crates/basin/tests/lbfgsb_ndarray.rs
@@ -1,15 +1,15 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
 //! L-Bfgs-B convergence tests over the ndarray backend. Mirrors
 //! `tests/lbfgsb_faer.rs` to confirm the `Array1<f64>` impl of
 //! [`basin::backend::AsFloatSliceMut`] plumbs through correctly.
 
+use crate::backend_aliases::ndarray::{Array1, array};
 use basin::problems::BoothBoxed;
 use basin::{
     BoxConstraints, CostFunction, Executor, Gradient, LbfgsState, Lbfgsb,
     MaxIter, ProjectedGradientTolerance,
 };
-use ndarray::{Array1, array};
 
 struct Rosen {
     l: Array1<f64>,
@@ -127,3 +127,6 @@ fn booth_slack_bounds_recover_unconstrained_minimum() {
     );
     assert!(result.cost() < 1e-8, "cost = {}", result.cost());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/levenberg_marquardt_faer.rs
+++ b/crates/basin/tests/levenberg_marquardt_faer.rs
@@ -1,8 +1,8 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::{ExponentialFit, PowellSingular, RosenbrockResiduals};
 use basin::{Executor, LevenbergMarquardt, NllsState, TerminationReason};
-use faer::Col;
 
 #[test]
 fn levenberg_marquardt_converges_on_rosenbrock_residuals() {
@@ -233,3 +233,6 @@ fn levenberg_marquardt_emits_solver_converged_via_first_order_optimality() {
 
     assert_eq!(result.reason, TerminationReason::SolverConverged);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/levenberg_marquardt_faer_sparse.rs
+++ b/crates/basin/tests/levenberg_marquardt_faer_sparse.rs
@@ -1,9 +1,9 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
+use crate::backend_aliases::faer::sparse::{SparseColMat, Triplet};
 use basin::problems::SparseLeastSquares;
 use basin::{Executor, LevenbergMarquardt, NllsState, TerminationReason};
-use faer::Col;
-use faer::sparse::{SparseColMat, Triplet};
 
 type FaerSparseLeastSquares =
     SparseLeastSquares<SparseColMat<usize, f64>, Col<f64>>;
@@ -94,3 +94,6 @@ fn levenberg_marquardt_emits_solver_converged_via_first_order_optimality() {
     .unwrap();
     assert_eq!(result.reason, TerminationReason::SolverConverged);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/levenberg_marquardt_nalgebra.rs
+++ b/crates/basin/tests/levenberg_marquardt_nalgebra.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::{ExponentialFit, PowellSingular, RosenbrockResiduals};
 use basin::{
     Executor, LevenbergMarquardt, NllsState, RelativeCostTolerance,
     TerminationReason,
 };
-use nalgebra::DVector;
 
 #[test]
 fn levenberg_marquardt_converges_on_rosenbrock_residuals() {
@@ -384,3 +384,6 @@ fn levenberg_marquardt_caches_residual_and_jacobian_across_iterations() {
         result.state.jacobian_evals()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/levenberg_marquardt_nalgebra_sparse.rs
+++ b/crates/basin/tests/levenberg_marquardt_nalgebra_sparse.rs
@@ -1,9 +1,9 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
+use crate::backend_aliases::nalgebra_sparse::{CooMatrix, CscMatrix};
 use basin::problems::SparseLeastSquares;
 use basin::{Executor, LevenbergMarquardt, NllsState, TerminationReason};
-use nalgebra::DVector;
-use nalgebra_sparse::{CooMatrix, CscMatrix};
 
 /// Mirror of the GN sparse fixture: 6×3 design with `b = A·[1,2,3]` so
 /// the closed-form least-squares minimum has zero residual at
@@ -96,3 +96,6 @@ fn levenberg_marquardt_emits_solver_converged_via_first_order_optimality() {
     .unwrap();
     assert_eq!(result.reason, TerminationReason::SolverConverged);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/levenberg_marquardt_ndarray.rs
+++ b/crates/basin/tests/levenberg_marquardt_ndarray.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
 //! Levenberg-Marquardt over the `ndarray` backend (`Array1<f64>`/
 //! `Array2<f64>`). Mirrors `tests/levenberg_marquardt_nalgebra.rs`: `Array2`'s
@@ -7,12 +7,12 @@
 //! damping dynamics, rank-deficiency recovery, and MINPACK-style termination
 //! are backend-independent; the assertions match the nalgebra mirror exactly.
 
+use crate::backend_aliases::ndarray::Array1;
 use basin::problems::{ExponentialFit, PowellSingular, RosenbrockResiduals};
 use basin::{
     Executor, LevenbergMarquardt, NllsState, RelativeCostTolerance,
     TerminationReason,
 };
-use ndarray::Array1;
 
 #[test]
 fn levenberg_marquardt_converges_on_rosenbrock_residuals() {
@@ -391,3 +391,6 @@ fn levenberg_marquardt_caches_residual_and_jacobian_across_iterations() {
         result.state.jacobian_evals()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/lincoa_public.rs
+++ b/crates/basin/tests/lincoa_public.rs
@@ -255,10 +255,10 @@ fn rho_tolerance_stops_early() {
 }
 
 /// Backend-generic: drive LINCOA on nalgebra `DMatrix`/`DVector`.
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 #[test]
 fn backend_generic_nalgebra() {
-    use nalgebra::{DMatrix, DVector};
+    use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 
     struct Proj {
         a: DMatrix<f64>,
@@ -306,10 +306,10 @@ fn backend_generic_nalgebra() {
 /// Backend-generic: drive LINCOA on ndarray `Array2`/`Array1`. Guards the
 /// support-matrix ✓ for ndarray; the param vector must satisfy
 /// `VectorLen + IndexMut` and the constraint matrix `MatTransposeVec`.
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 #[test]
 fn backend_generic_ndarray() {
-    use ndarray::{Array1, Array2};
+    use crate::backend_aliases::ndarray::{Array1, Array2};
 
     struct Proj {
         a: Array2<f64>,
@@ -356,10 +356,10 @@ fn backend_generic_ndarray() {
 
 /// Backend-generic: drive LINCOA on faer `Mat`/`Col`. Guards the
 /// support-matrix ✓ for faer.
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 #[test]
 fn backend_generic_faer() {
-    use faer::{Col, Mat};
+    use crate::backend_aliases::faer::{Col, Mat};
 
     struct Proj {
         a: Mat<f64>,
@@ -400,3 +400,6 @@ fn backend_generic_faer() {
         "x = {x:?}"
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/ma_ls_ch_cma_faer.rs
+++ b/crates/basin/tests/ma_ls_ch_cma_faer.rs
@@ -3,11 +3,11 @@
 //! deeper algorithmic invariants are covered by the nalgebra mirror
 //! test (`tests/ma_ls_ch_cma_nalgebra.rs`).
 
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::{Col, Mat};
 use basin::problems::{RastriginBoxed, SphereBoxed};
 use basin::{Executor, MaLsChCma, MaLsChState, MaxCostEvals};
-use faer::{Col, Mat};
 
 #[test]
 fn converges_on_sphere_d10() {
@@ -43,3 +43,6 @@ fn converges_on_rastrigin_d10() {
         result.cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/ma_ls_ch_cma_nalgebra.rs
+++ b/crates/basin/tests/ma_ls_ch_cma_nalgebra.rs
@@ -7,14 +7,14 @@
 //! failure on a NaN-returning problem, exercised at the boundary via
 //! `inner_executor.rs`).
 
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::problems::{RastriginBoxed, SphereBoxed};
 use basin::{
     Executor, MaLsChCma, MaLsChState, MaxCostEvals, PopulationState,
     StepOutcome,
 };
-use nalgebra::{DMatrix, DVector};
 
 /// Sphere with a box for SSGA initial sampling: the easy canary that
 /// any working population solver should crush.
@@ -244,3 +244,6 @@ fn population_stays_sorted_ascending() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/ma_ls_ch_cma_ndarray.rs
+++ b/crates/basin/tests/ma_ls_ch_cma_ndarray.rs
@@ -3,11 +3,11 @@
 //! the deeper algorithmic invariants are covered by the nalgebra
 //! mirror test (`tests/ma_ls_ch_cma_nalgebra.rs`).
 
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
+use crate::backend_aliases::ndarray::{Array1, Array2};
 use basin::problems::{RastriginBoxed, SphereBoxed};
 use basin::{Executor, MaLsChCma, MaLsChState, MaxCostEvals};
-use ndarray::{Array1, Array2};
 
 #[test]
 fn converges_on_sphere_d10() {
@@ -47,3 +47,6 @@ fn converges_on_rastrigin_d10() {
         result.cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/ma_ls_ch_sw_faer.rs
+++ b/crates/basin/tests/ma_ls_ch_sw_faer.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
 //! faer-backend smoke mirror for [`MaLsChSw`]; the deep tests live in
 //! `tests/ma_ls_ch_sw_nalgebra.rs`. Vector type only—no `Mat`.
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::SphereBoxed;
 use basin::{Executor, MaLsChSw, MaLsChSwState, MaxCostEvals};
-use faer::Col;
 
 #[test]
 fn converges_on_sphere_d10() {
@@ -24,3 +24,6 @@ fn converges_on_sphere_d10() {
         result.cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/ma_ls_ch_sw_nalgebra.rs
+++ b/crates/basin/tests/ma_ls_ch_sw_nalgebra.rs
@@ -1,15 +1,15 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
 //! nalgebra-backend tests for [`MaLsChSw`]: the deep mirror. Covers
 //! convergence, reproducibility, the chain-resume mechanism, and the
 //! sorted-population invariant; the other backends run smoke mirrors.
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::{RastriginBoxed, SphereBoxed};
 use basin::{
     Executor, MaLsChSw, MaLsChSwState, MaxCostEvals, PopulationState,
     StepOutcome,
 };
-use nalgebra::DVector;
 
 fn boxed_sphere(n: usize) -> SphereBoxed<DVector<f64>> {
     SphereBoxed::new(
@@ -134,3 +134,6 @@ fn population_stays_sorted_ascending() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/ma_ls_ch_sw_ndarray.rs
+++ b/crates/basin/tests/ma_ls_ch_sw_ndarray.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
 //! ndarray-backend smoke mirror for [`MaLsChSw`]; the deep tests live
 //! in `tests/ma_ls_ch_sw_nalgebra.rs`. Vector type only—no `Array2`.
 
+use crate::backend_aliases::ndarray::Array1;
 use basin::problems::SphereBoxed;
 use basin::{Executor, MaLsChSw, MaLsChSwState, MaxCostEvals};
-use ndarray::Array1;
 
 #[test]
 fn converges_on_sphere_d10() {
@@ -26,3 +26,6 @@ fn converges_on_sphere_d10() {
         result.cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/mads_constrained.rs
+++ b/crates/basin/tests/mads_constrained.rs
@@ -125,10 +125,10 @@ fn respects_eval_budget() {
 /// Backend-generic: drive constrained MADS on nalgebra `DVector`. Guards the
 /// support-matrix ✓ for nalgebra (the param vector needs
 /// `VectorLen + Index + IndexMut`).
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 #[test]
 fn backend_generic_nalgebra() {
-    use nalgebra::DVector;
+    use crate::backend_aliases::nalgebra::DVector;
 
     struct Disk;
     impl CostFunction for Disk {
@@ -174,10 +174,10 @@ fn backend_generic_nalgebra() {
 }
 
 /// Backend-generic: drive constrained MADS on ndarray `Array1`.
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 #[test]
 fn backend_generic_ndarray() {
-    use ndarray::Array1;
+    use crate::backend_aliases::ndarray::Array1;
 
     struct Disk;
     impl CostFunction for Disk {
@@ -223,10 +223,10 @@ fn backend_generic_ndarray() {
 }
 
 /// Backend-generic: drive constrained MADS on faer `Col`.
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 #[test]
 fn backend_generic_faer() {
-    use faer::Col;
+    use crate::backend_aliases::faer::Col;
 
     struct Disk;
     impl CostFunction for Disk {
@@ -267,3 +267,6 @@ fn backend_generic_faer() {
     let x = result.best_param();
     assert!(x[0] * x[0] + x[1] * x[1] <= 1.0 + 1e-6, "infeasible {x:?}");
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/mads_public.rs
+++ b/crates/basin/tests/mads_public.rs
@@ -192,10 +192,10 @@ fn outperforms_nelder_mead_on_discontinuous_step() {
 
 /// Backend-generic over the parameter vector: drive MADS on `nalgebra`'s
 /// `DVector` to prove the `V`-generic solver and state work outside `Vec<f64>`.
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 #[test]
 fn backend_generic_nalgebra() {
-    use nalgebra::DVector;
+    use crate::backend_aliases::nalgebra::DVector;
 
     struct SphereN;
     impl CostFunction for SphereN {
@@ -228,10 +228,10 @@ fn backend_generic_nalgebra() {
 }
 
 /// Backend-generic over `ndarray`'s `Array1`.
-#[cfg(feature = "ndarray")]
+#[cfg(feature = "ndarray_all")]
 #[test]
 fn backend_generic_ndarray() {
-    use ndarray::Array1;
+    use crate::backend_aliases::ndarray::Array1;
 
     struct SphereA;
     impl CostFunction for SphereA {
@@ -264,10 +264,10 @@ fn backend_generic_ndarray() {
 }
 
 /// Backend-generic over `faer`'s `Col` vector.
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 #[test]
 fn backend_generic_faer() {
-    use faer::Col;
+    use crate::backend_aliases::faer::Col;
 
     struct SphereF;
     impl CostFunction for SphereF {
@@ -295,3 +295,6 @@ fn backend_generic_faer() {
         result.best_cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/newuoa_public.rs
+++ b/crates/basin/tests/newuoa_public.rs
@@ -100,10 +100,10 @@ fn rho_tolerance_stops_early() {
 
 /// Backend-generic over the parameter vector: drive NEWUOA on `nalgebra`'s
 /// `DVector` to prove the `V`-generic solver and state work outside `Vec<f64>`.
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 #[test]
 fn backend_generic_nalgebra() {
-    use nalgebra::DVector;
+    use crate::backend_aliases::nalgebra::DVector;
 
     struct RosenbrockN;
     impl CostFunction for RosenbrockN {
@@ -139,3 +139,6 @@ fn backend_generic_nalgebra() {
         result.best_cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/numdiff.rs
+++ b/crates/basin/tests/numdiff.rs
@@ -36,14 +36,14 @@ fn gradient_descent_on_finite_diff_sphere_converges() {
     }
 }
 
-#[cfg(feature = "nalgebra")]
+#[cfg(feature = "nalgebra_all")]
 mod nalgebra {
+    use crate::backend_aliases::nalgebra::DVector;
     use basin::problems::{Rosenbrock, RosenbrockResiduals};
     use basin::{
         BasicState, Executor, FiniteDiff, GradientTolerance,
         LevenbergMarquardt, Method, NllsState, TerminationReason, TrustRegion,
     };
-    use nalgebra::DVector;
 
     #[test]
     fn trust_region_on_finite_diff_hessian_minimizes_rosenbrock() {
@@ -114,13 +114,13 @@ mod nalgebra {
     }
 }
 
-#[cfg(feature = "faer")]
+#[cfg(feature = "faer_all")]
 mod faer {
+    use crate::backend_aliases::faer::Col;
     use basin::problems::RosenbrockResiduals;
     use basin::{
         Executor, FiniteDiff, LevenbergMarquardt, NllsState, TerminationReason,
     };
-    use faer::Col;
 
     #[test]
     fn levenberg_marquardt_on_finite_diff_jacobian_matches_analytic() {
@@ -149,3 +149,6 @@ mod faer {
         );
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/projected_gradient_descent_faer.rs
+++ b/crates/basin/tests/projected_gradient_descent_faer.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::BoothBoxed;
 use basin::{
     Backtracking, BasicState, Executor, ProjectedGradientDescent,
     ProjectedGradientTolerance, TerminationReason,
 };
-use faer::Col;
 
 fn col(values: [f64; 2]) -> Col<f64> {
     Col::<f64>::from_fn(2, |i| values[i])
@@ -104,3 +104,6 @@ fn projected_gradient_tolerance_triggers_at_corner_minimum() {
 
     assert_eq!(result.reason, TerminationReason::ProjectedGradientTolerance);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/projected_gradient_descent_nalgebra.rs
+++ b/crates/basin/tests/projected_gradient_descent_nalgebra.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::BoothBoxed;
 use basin::{
     Backtracking, BasicState, Executor, ProjectedGradientDescent,
     ProjectedGradientTolerance, TerminationReason,
 };
-use nalgebra::DVector;
 
 /// Slack bounds: the unconstrained Booth minimum (1, 3) is interior to
 /// [-5, 5]², so the projected solver must reach it.
@@ -106,3 +106,6 @@ fn projected_gradient_tolerance_triggers_at_corner_minimum() {
 
     assert_eq!(result.reason, TerminationReason::ProjectedGradientTolerance);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/projected_gradient_descent_ndarray.rs
+++ b/crates/basin/tests/projected_gradient_descent_ndarray.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
+use crate::backend_aliases::ndarray::Array1;
 use basin::problems::BoothBoxed;
 use basin::{
     Backtracking, BasicState, Executor, ProjectedGradientDescent,
     ProjectedGradientTolerance, TerminationReason,
 };
-use ndarray::Array1;
 
 #[test]
 fn slack_bounds_recover_unconstrained_minimum() {
@@ -103,3 +103,6 @@ fn projected_gradient_tolerance_triggers_at_corner_minimum() {
 
     assert_eq!(result.reason, TerminationReason::ProjectedGradientTolerance);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/random_search_faer.rs
+++ b/crates/basin/tests/random_search_faer.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::BoothBoxed;
 use basin::{
     BasicPopulationState, Executor, PopulationState, RandomSearch, State,
     StepOutcome,
 };
-use faer::Col;
 
 fn col2(a: f64, b: f64) -> Col<f64> {
     Col::<f64>::from_fn(2, |i| if i == 0 { a } else { b })
@@ -100,3 +100,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/random_search_nalgebra.rs
+++ b/crates/basin/tests/random_search_nalgebra.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::BoothBoxed;
 use basin::{
     BasicPopulationState, Executor, PopulationState, RandomSearch, State,
     StepOutcome,
 };
-use nalgebra::DVector;
 
 /// Same seed → same trajectory, on the nalgebra backend. Sample
 /// reproducibility is platform- and backend-independent.
@@ -117,3 +117,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/random_search_ndarray.rs
+++ b/crates/basin/tests/random_search_ndarray.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
+use crate::backend_aliases::ndarray::Array1;
 use basin::problems::BoothBoxed;
 use basin::{
     BasicPopulationState, Executor, PopulationState, RandomSearch, State,
     StepOutcome,
 };
-use ndarray::Array1;
 
 #[test]
 fn same_seed_yields_identical_trajectory() {
@@ -109,3 +109,6 @@ fn population_invariants_hold_after_iteration() {
         }
     }
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/rosenbrock_faer.rs
+++ b/crates/basin/tests/rosenbrock_faer.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::Rosenbrock;
 use basin::{
     Backtracking, BasicSimplexState, BasicState, CostFunction, Executor,
     GradientDescent, NelderMead,
 };
-use faer::Col;
 
 #[test]
 fn gradient_descent_with_faer_col() {
@@ -69,3 +69,6 @@ fn nelder_mead_with_faer_col() {
 
     assert!(result.cost() < 1e-6, "cost = {}", result.cost());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/rosenbrock_nalgebra.rs
+++ b/crates/basin/tests/rosenbrock_nalgebra.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::Rosenbrock;
 use basin::{
     Backtracking, BasicSimplexState, BasicState, CostFunction, Executor,
     GradientDescent, NelderMead,
 };
-use nalgebra::DVector;
 
 #[test]
 fn gradient_descent_with_nalgebra_dvector() {
@@ -69,3 +69,6 @@ fn nelder_mead_with_nalgebra_dvector() {
 
     assert!(result.cost() < 1e-6, "cost = {}", result.cost());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/rosenbrock_ndarray.rs
+++ b/crates/basin/tests/rosenbrock_ndarray.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
+use crate::backend_aliases::ndarray::{Array1, array};
 use basin::problems::Rosenbrock;
 use basin::{
     Backtracking, BasicSimplexState, BasicState, CostFunction, Executor,
     GradientDescent, NelderMead,
 };
-use ndarray::{Array1, array};
 
 #[test]
 fn gradient_descent_with_ndarray_array1() {
@@ -69,3 +69,6 @@ fn nelder_mead_with_ndarray_array1() {
 
     assert!(result.cost() < 1e-6, "cost = {}", result.cost());
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/solis_wets_faer.rs
+++ b/crates/basin/tests/solis_wets_faer.rs
@@ -1,12 +1,12 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
 //! faer-backend mirror of the `Vec<f64>` Solis-Wets suite
 //! (`tests/solis_wets_vec.rs`): reduced to the checks that exercise the
 //! per-backend trait wiring.
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::Sphere;
 use basin::{Executor, RhoTolerance, SolisWets, TerminationReason};
-use faer::Col;
 
 fn col(values: &[f64]) -> Col<f64> {
     Col::<f64>::from_fn(values.len(), |i| values[i])
@@ -49,3 +49,6 @@ fn converges_on_sphere_5d_via_rho_tolerance() {
         result.cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/solis_wets_nalgebra.rs
+++ b/crates/basin/tests/solis_wets_nalgebra.rs
@@ -1,12 +1,12 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
 //! nalgebra-backend mirror of the `Vec<f64>` Solis-Wets suite
 //! (`tests/solis_wets_vec.rs`): reduced to the checks that exercise the
 //! per-backend trait wiring.
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::Sphere;
 use basin::{Executor, RhoTolerance, SolisWets, TerminationReason};
-use nalgebra::DVector;
 
 #[test]
 fn same_seed_yields_identical_trajectory() {
@@ -45,3 +45,6 @@ fn converges_on_sphere_5d_via_rho_tolerance() {
         result.cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/solis_wets_ndarray.rs
+++ b/crates/basin/tests/solis_wets_ndarray.rs
@@ -1,12 +1,12 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
 //! ndarray-backend mirror of the `Vec<f64>` Solis-Wets suite
 //! (`tests/solis_wets_vec.rs`): reduced to the checks that exercise the
 //! per-backend trait wiring.
 
+use crate::backend_aliases::ndarray::Array1;
 use basin::problems::Sphere;
 use basin::{Executor, RhoTolerance, SolisWets, TerminationReason};
-use ndarray::Array1;
 
 #[test]
 fn same_seed_yields_identical_trajectory() {
@@ -45,3 +45,6 @@ fn converges_on_sphere_5d_via_rho_tolerance() {
         result.cost()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/support/backend_aliases.rs
+++ b/crates/basin/tests/support/backend_aliases.rs
@@ -1,0 +1,59 @@
+#![allow(clippy::single_component_path_imports, unused_imports)]
+
+#[cfg(feature = "nalgebra_v0_35")]
+pub(crate) use nalgebra;
+#[cfg(all(
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    )),
+    feature = "nalgebra_v0_32"
+))]
+pub(crate) use nalgebra_0_32 as nalgebra;
+#[cfg(all(
+    not(any(feature = "nalgebra_v0_35", feature = "nalgebra_v0_34")),
+    feature = "nalgebra_v0_33"
+))]
+pub(crate) use nalgebra_0_33 as nalgebra;
+#[cfg(all(not(feature = "nalgebra_v0_35"), feature = "nalgebra_v0_34"))]
+pub(crate) use nalgebra_0_34 as nalgebra;
+
+#[cfg(feature = "nalgebra_v0_35")]
+pub(crate) use nalgebra_sparse;
+#[cfg(all(
+    not(any(
+        feature = "nalgebra_v0_35",
+        feature = "nalgebra_v0_34",
+        feature = "nalgebra_v0_33"
+    )),
+    feature = "nalgebra_v0_32"
+))]
+pub(crate) use nalgebra_sparse_0_9 as nalgebra_sparse;
+#[cfg(all(
+    not(any(feature = "nalgebra_v0_35", feature = "nalgebra_v0_34")),
+    feature = "nalgebra_v0_33"
+))]
+pub(crate) use nalgebra_sparse_0_10 as nalgebra_sparse;
+#[cfg(all(not(feature = "nalgebra_v0_35"), feature = "nalgebra_v0_34"))]
+pub(crate) use nalgebra_sparse_0_11 as nalgebra_sparse;
+
+#[cfg(feature = "ndarray_v0_17")]
+pub(crate) use ndarray;
+#[cfg(all(
+    not(any(feature = "ndarray_v0_17", feature = "ndarray_v0_16")),
+    feature = "ndarray_v0_15"
+))]
+pub(crate) use ndarray_0_15 as ndarray;
+#[cfg(all(not(feature = "ndarray_v0_17"), feature = "ndarray_v0_16"))]
+pub(crate) use ndarray_0_16 as ndarray;
+
+#[cfg(feature = "faer_v0_24")]
+pub(crate) use faer;
+#[cfg(all(
+    not(any(feature = "faer_v0_24", feature = "faer_v0_23")),
+    feature = "faer_v0_22"
+))]
+pub(crate) use faer_0_22 as faer;
+#[cfg(all(not(feature = "faer_v0_24"), feature = "faer_v0_23"))]
+pub(crate) use faer_0_23 as faer;

--- a/crates/basin/tests/test.rs
+++ b/crates/basin/tests/test.rs
@@ -6,13 +6,13 @@
 //! `x₀ + x₁ ≤ 2`. The unconstrained minimum `(2,2)` is infeasible, so the
 //! constrained optimum is the projection onto the line `x₀ + x₁ = 2` nearest
 //! `(2,2)`, namely `(1, 1)`.
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::{DMatrix, DVector};
 use basin::{
     Backtracking, BarrierMethod, BasicState, CostFunction, Executor, Gradient,
     GradientDescent, LinearInequalityConstraints, TerminationReason,
 };
-use nalgebra::{DMatrix, DVector};
 
 // 1. Define the problem. The objective and its gradient are the usual
 //    `CostFunction`/`Gradient` traits; the constraints are the new
@@ -106,3 +106,6 @@ fn barrier_method_tour() {
     assert_eq!(result.reason, TerminationReason::SolverConverged);
     assert!((x[0] - 1.0).abs() < 1e-4 && (x[1] - 1.0).abs() < 1e-4);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/trf_faer.rs
+++ b/crates/basin/tests/trf_faer.rs
@@ -1,8 +1,8 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
 use basin::problems::BoothBoxedResiduals;
 use basin::{Executor, MaxIter, NllsState, TerminationReason, Trf};
-use faer::Col;
 
 #[test]
 fn trf_with_slack_bounds_reaches_unconstrained_min() {
@@ -100,3 +100,6 @@ fn trf_emits_solver_converged_via_scaled_first_order_optimality() {
 
     assert_eq!(result.reason, TerminationReason::SolverConverged);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/trf_faer_sparse.rs
+++ b/crates/basin/tests/trf_faer_sparse.rs
@@ -1,9 +1,9 @@
-#![cfg(feature = "faer")]
+#![cfg(feature = "faer_all")]
 
+use crate::backend_aliases::faer::Col;
+use crate::backend_aliases::faer::sparse::{SparseColMat, Triplet};
 use basin::problems::SparseLeastSquaresBoxed;
 use basin::{Executor, NllsState, TerminationReason, Trf};
-use faer::Col;
-use faer::sparse::{SparseColMat, Triplet};
 
 type FaerSparseLeastSquaresBoxed =
     SparseLeastSquaresBoxed<SparseColMat<usize, f64>, Col<f64>>;
@@ -90,3 +90,6 @@ fn trf_emits_solver_converged_via_scaled_first_order_optimality() {
         .unwrap();
     assert_eq!(result.reason, TerminationReason::SolverConverged);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/trf_nalgebra.rs
+++ b/crates/basin/tests/trf_nalgebra.rs
@@ -1,8 +1,8 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
 use basin::problems::BoothBoxedResiduals;
 use basin::{Executor, MaxIter, NllsState, TerminationReason, Trf};
-use nalgebra::DVector;
 
 #[test]
 fn trf_with_slack_bounds_reaches_unconstrained_min() {
@@ -168,3 +168,6 @@ fn trf_caches_residual_and_jacobian_across_iterations() {
         result.state.jacobian_evals()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/trf_nalgebra_sparse.rs
+++ b/crates/basin/tests/trf_nalgebra_sparse.rs
@@ -1,9 +1,9 @@
-#![cfg(feature = "nalgebra")]
+#![cfg(feature = "nalgebra_all")]
 
+use crate::backend_aliases::nalgebra::DVector;
+use crate::backend_aliases::nalgebra_sparse::{CooMatrix, CscMatrix};
 use basin::problems::SparseLeastSquaresBoxed;
 use basin::{Executor, NllsState, TerminationReason, Trf};
-use nalgebra::DVector;
-use nalgebra_sparse::{CooMatrix, CscMatrix};
 
 /// 6×3 design: identity stack + pairwise-sum rows. With `b = A·[1, 2, 3]`,
 /// the closed-form unconstrained least-squares minimum lands exactly at
@@ -97,3 +97,6 @@ fn trf_emits_solver_converged_via_scaled_first_order_optimality() {
         .unwrap();
     assert_eq!(result.reason, TerminationReason::SolverConverged);
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/basin/tests/trf_ndarray.rs
+++ b/crates/basin/tests/trf_ndarray.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "ndarray")]
+#![cfg(feature = "ndarray_all")]
 
 //! Trust-region-reflective over the `ndarray` backend (`Array1<f64>`/
 //! `Array2<f64>`). Mirrors `tests/trf_nalgebra.rs`: `Array2`'s `GramMatrix`,
@@ -7,9 +7,9 @@
 //! scaled-gradient dynamics backend-independent; the assertions match the
 //! nalgebra mirror exactly.
 
+use crate::backend_aliases::ndarray::Array1;
 use basin::problems::BoothBoxedResiduals;
 use basin::{Executor, MaxIter, NllsState, TerminationReason, Trf};
-use ndarray::Array1;
 
 #[test]
 fn trf_with_slack_bounds_reaches_unconstrained_min() {
@@ -175,3 +175,6 @@ fn trf_caches_residual_and_jacobian_across_iterations() {
         result.state.jacobian_evals()
     );
 }
+
+#[path = "support/backend_aliases.rs"]
+mod backend_aliases;

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -31,10 +31,14 @@ publish = false
 basin = { path = "../basin", features = ["nalgebra", "faer", "problems"] }
 levenberg-marquardt = "0.15"
 nalgebra = "0.34"
+# Workspace `--all-features` makes Basin select its newest enabled nalgebra.
+# Keep the benchmark default on 0.34 for the like-for-like LM comparison, but
+# compile its Basin side against 0.35 in the all-feature maintenance build.
+nalgebra_latest = { package = "nalgebra", version = "0.35", optional = true }
 faer = { version = "0.24", default-features = false, features = ["std", "linalg"] }
 # argmin on its default `Vec<f64>` backend. default-features keeps the
-# `vec` math impls (via argmin-math) and `rand`; we don't enable any
-# per-version backend feature (the explosion basin's tenet 2 avoids).
+# `vec` math impls (via argmin-math) and `rand`; this benchmark does not
+# need one of argmin's optional linear-algebra backends.
 argmin = "0.11"
 argmin-math = { version = "0.5", features = ["vec"] }
 # gomez bundles its own nalgebra (0.32). That's a major mismatch with
@@ -60,6 +64,7 @@ nlopt = "0.8"
 rayon = { version = "1", optional = true }
 
 [features]
+basin-latest = ["basin/nalgebra_latest", "dep:nalgebra_latest"]
 # Off by default so the axis-3 competitor benches (`compare`, `gd_nm`)
 # compile basin *without* rayon—a single-threaded basin vs a
 # single-threaded argmin/lm/gomez/nlopt, with no parallelism confound.

--- a/crates/competitor-bench/benches/compare.rs
+++ b/crates/competitor-bench/benches/compare.rs
@@ -25,7 +25,10 @@ use criterion::{
     BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main,
 };
 use faer::Col;
-use nalgebra::DVector;
+#[cfg(not(feature = "basin-latest"))]
+use nalgebra::DVector as BasinDVector;
+#[cfg(feature = "basin-latest")]
+use nalgebra_latest::DVector as BasinDVector;
 
 fn basin_lm<V, M>() -> LevenbergMarquardt<V, M> {
     LevenbergMarquardt::new()
@@ -54,10 +57,10 @@ fn bench_exp_fit(c: &mut Criterion) {
         b.iter_batched(
             || {
                 (
-                    ExponentialFit::<DVector<f64>>::sampled(
+                    ExponentialFit::<BasinDVector<f64>>::sampled(
                         1.0e5, -1.0, 10, 0.4,
                     ),
-                    DVector::from_vec(vec![5.0e4, -0.3]),
+                    BasinDVector::from_vec(vec![5.0e4, -0.3]),
                 )
             },
             |(p, x0)| {
@@ -112,8 +115,8 @@ fn bench_powell(c: &mut Criterion) {
         b.iter_batched(
             || {
                 (
-                    PowellSingular::<DVector<f64>>::new(),
-                    DVector::from_vec(vec![3.0, -1.0, 0.0, 1.0]),
+                    PowellSingular::<BasinDVector<f64>>::new(),
+                    BasinDVector::from_vec(vec![3.0, -1.0, 0.0, 1.0]),
                 )
             },
             |(p, x0)| {
@@ -175,8 +178,8 @@ fn bench_vardim(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     (
-                        VarDim::<DVector<f64>>::new(n),
-                        DVector::from_vec(vardim_start(n)),
+                        VarDim::<BasinDVector<f64>>::new(n),
+                        BasinDVector::from_vec(vardim_start(n)),
                     )
                 },
                 |(p, x0)| {
@@ -235,8 +238,8 @@ fn bench_underdet(c: &mut Criterion) {
         g.bench_function(BenchmarkId::from_parameter("basin/nalgebra"), |b| {
             b.iter_batched(
                 || {
-                    let p = UnderDet::<DVector<f64>>::new(m, n);
-                    let x0 = DVector::from_vec(p.start());
+                    let p = UnderDet::<BasinDVector<f64>>::new(m, n);
+                    let x0 = BasinDVector::from_vec(p.start());
                     (p, x0)
                 },
                 |(p, x0)| {

--- a/crates/competitor-bench/src/bin/verify.rs
+++ b/crates/competitor-bench/src/bin/verify.rs
@@ -14,7 +14,10 @@ use competitor_bench::{
 };
 use faer::Col;
 use levenberg_marquardt::LeastSquaresProblem;
-use nalgebra::DVector;
+#[cfg(not(feature = "basin-latest"))]
+use nalgebra::DVector as BasinDVector;
+#[cfg(feature = "basin-latest")]
+use nalgebra_latest::DVector as BasinDVector;
 
 /// basin LM configured to match the lm crate's default stopping rules:
 /// MINPACK gtol/ftol/xtol all at `30·ε`, absolute gradient test off.
@@ -45,9 +48,9 @@ fn main() {
     );
 
     let r = Executor::new(
-        ExponentialFit::<DVector<f64>>::sampled(1.0e5, -1.0, 10, 0.4),
+        ExponentialFit::<BasinDVector<f64>>::sampled(1.0e5, -1.0, 10, 0.4),
         basin_lm(),
-        NllsState::new(DVector::from_vec(vec![5.0e4, -0.3])),
+        NllsState::new(BasinDVector::from_vec(vec![5.0e4, -0.3])),
     )
     .max_iter(200)
     .run()
@@ -98,9 +101,9 @@ fn main() {
     );
 
     let r = Executor::new(
-        PowellSingular::<DVector<f64>>::new(),
+        PowellSingular::<BasinDVector<f64>>::new(),
         basin_lm(),
-        NllsState::new(DVector::from_vec(vec![3.0, -1.0, 0.0, 1.0])),
+        NllsState::new(BasinDVector::from_vec(vec![3.0, -1.0, 0.0, 1.0])),
     )
     .max_iter(200)
     .run()
@@ -161,9 +164,9 @@ fn main() {
         );
 
         let r = Executor::new(
-            VarDim::<DVector<f64>>::new(n),
+            VarDim::<BasinDVector<f64>>::new(n),
             basin_lm(),
-            NllsState::new(DVector::from_vec(start.clone())),
+            NllsState::new(BasinDVector::from_vec(start.clone())),
         )
         .max_iter(500)
         .run()
@@ -219,8 +222,8 @@ fn main() {
             rep.termination
         );
 
-        let p = UnderDet::<DVector<f64>>::new(m, n);
-        let x0 = DVector::from_vec(p.start());
+        let p = UnderDet::<BasinDVector<f64>>::new(m, n);
+        let x0 = BasinDVector::from_vec(p.start());
         let r = Executor::new(p, basin_lm(), NllsState::new(x0))
             .max_iter(500)
             .run()

--- a/crates/competitor-bench/src/lib.rs
+++ b/crates/competitor-bench/src/lib.rs
@@ -276,6 +276,40 @@ impl Jacobian for VarDim<DVector<f64>> {
     }
 }
 
+#[cfg(feature = "basin-latest")]
+impl Residual for VarDim<nalgebra_latest::DVector<f64>> {
+    type Param = nalgebra_latest::DVector<f64>;
+    type Output = nalgebra_latest::DVector<f64>;
+    type Error = std::convert::Infallible;
+
+    fn residual(
+        &self,
+        x: &nalgebra_latest::DVector<f64>,
+    ) -> Result<nalgebra_latest::DVector<f64>, Self::Error> {
+        let mut out = vec![0.0; self.n + 2];
+        vardim_residual(x.as_slice(), &mut out);
+        Ok(nalgebra_latest::DVector::from_vec(out))
+    }
+}
+
+#[cfg(feature = "basin-latest")]
+impl Jacobian for VarDim<nalgebra_latest::DVector<f64>> {
+    type Jacobian = nalgebra_latest::DMatrix<f64>;
+
+    fn jacobian(
+        &self,
+        x: &nalgebra_latest::DVector<f64>,
+    ) -> Result<nalgebra_latest::DMatrix<f64>, Self::Error> {
+        let mut out = vec![0.0; (self.n + 2) * self.n];
+        vardim_jacobian_row_major(x.as_slice(), &mut out);
+        Ok(nalgebra_latest::DMatrix::from_row_slice(
+            self.n + 2,
+            self.n,
+            &out,
+        ))
+    }
+}
+
 impl Residual for VarDim<Col<f64>> {
     type Param = Col<f64>;
     type Output = Col<f64>;
@@ -466,6 +500,40 @@ impl Jacobian for UnderDet<DVector<f64>> {
         let mut out = vec![0.0; self.data.m * self.data.n];
         self.data.jacobian_row_major(x.as_slice(), &mut out);
         Ok(DMatrix::from_row_slice(self.data.m, self.data.n, &out))
+    }
+}
+
+#[cfg(feature = "basin-latest")]
+impl Residual for UnderDet<nalgebra_latest::DVector<f64>> {
+    type Param = nalgebra_latest::DVector<f64>;
+    type Output = nalgebra_latest::DVector<f64>;
+    type Error = std::convert::Infallible;
+
+    fn residual(
+        &self,
+        x: &nalgebra_latest::DVector<f64>,
+    ) -> Result<nalgebra_latest::DVector<f64>, Self::Error> {
+        let mut out = vec![0.0; self.data.m];
+        self.data.residual(x.as_slice(), &mut out);
+        Ok(nalgebra_latest::DVector::from_vec(out))
+    }
+}
+
+#[cfg(feature = "basin-latest")]
+impl Jacobian for UnderDet<nalgebra_latest::DVector<f64>> {
+    type Jacobian = nalgebra_latest::DMatrix<f64>;
+
+    fn jacobian(
+        &self,
+        x: &nalgebra_latest::DVector<f64>,
+    ) -> Result<nalgebra_latest::DMatrix<f64>, Self::Error> {
+        let mut out = vec![0.0; self.data.m * self.data.n];
+        self.data.jacobian_row_major(x.as_slice(), &mut out);
+        Ok(nalgebra_latest::DMatrix::from_row_slice(
+            self.data.m,
+            self.data.n,
+            &out,
+        ))
     }
 }
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -3,11 +3,11 @@
   ...
 }:
 {
-  # LP64 OpenBLAS for running the `nalgebra-lapack` feature's tests locally.
-  # That feature forwards `lapack-custom`, so LAPACK symbols are supplied at
-  # link time — point RUSTFLAGS at this path:
+  # LP64 OpenBLAS for running the nalgebra LAPACK feature tests locally.
+  # The latest feature forwards `lapack-custom`, so LAPACK symbols are supplied
+  # at link time—point RUSTFLAGS at this path:
   #   RUSTFLAGS="-L $OPENBLAS_LP64_LIB -l openblas" \
-  #     cargo test -p basin --features nalgebra-lapack --test lapack_nalgebra
+  #     cargo test -p basin --features nalgebra_latest-lapack --test lapack_nalgebra
   # `openblasCompat` is the LP64 (32-bit int) build that matches `lapack-sys`;
   # the default `openblas` is ILP64 on 64-bit and segfaults at runtime.
   env.OPENBLAS_LP64_LIB = "${pkgs.openblasCompat}/lib";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.89.0"
 targets = ["wasm32-unknown-unknown"]

--- a/web/scripts/collect-benchmarks.ts
+++ b/web/scripts/collect-benchmarks.ts
@@ -9,7 +9,7 @@
  * `web/src/lib/data/backend-benchmarks.json`.
  *
  * Run with: `npm run collect:benchmarks` (uses tsx). Run the bench first:
- *   cargo bench --features nalgebra,ndarray,faer --bench solver_backends
+ *   cargo bench --features nalgebra_latest,ndarray_latest,faer_latest --bench solver_backends
  *
  * The pipeline is deliberately off CI: timings are machine-specific and
  * shared runners are noisy. Refresh locally and commit the regenerated JSON.
@@ -89,7 +89,7 @@ if (!existsSync(criterionDir)) {
     console.error(`✗ no criterion output at ${criterionDir}`);
     console.error(
         "  run the bench first:\n" +
-            "  cargo bench --features nalgebra,ndarray,faer --bench solver_backends",
+            "  cargo bench --features nalgebra_latest,ndarray_latest,faer_latest --bench solver_backends",
     );
     process.exit(1);
 }
@@ -156,7 +156,7 @@ for (const estimatesPath of findEstimates(criterionDir)) {
 if (results.length === 0) {
     console.error(
         "✗ found criterion output but no solver_backends groups—run:\n" +
-            "  cargo bench --features nalgebra,ndarray,faer --bench solver_backends",
+            "  cargo bench --features nalgebra_latest,ndarray_latest,faer_latest --bench solver_backends",
     );
     process.exit(1);
 }

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -11,7 +11,7 @@
         },
         {
             title: "Multiple backends",
-            body: "Run on plain Vec<f64>, nalgebra, ndarray, or faer. Each backend sits behind a single feature: no per-version feature explosion.",
+            body: "Run on plain Vec<f64>, or select a compatible nalgebra, ndarray, or faer release with exact-version and latest feature aliases.",
         },
         {
             title: "First-class constraints",

--- a/web/src/routes/docs/getting-started/+page.svx
+++ b/web/src/routes/docs/getting-started/+page.svx
@@ -9,17 +9,22 @@ cargo add basin
 ```
 
 Basin works on plain `Vec<f64>` out of the box. Linear-algebra backends are
-opt-in, one feature each. For example, to use the
+opt-in. For example, to use the latest supported
 [nalgebra](https://nalgebra.org) backend (required by some solvers, see
 [Solvers](../solvers/)):
 
 ```sh
-cargo add basin --features nalgebra
+cargo add basin --features nalgebra_latest
 ```
 
-Available backend features: `nalgebra`, `ndarray`, `faer`. The `problems`
-feature (a corpus of standard test functions) is on by default; disable it with
-`default-features = false` to shrink a wasm build.
+The moving aliases are `nalgebra_latest`, `ndarray_latest`, and `faer_latest`.
+Exact version features are also available for nalgebra 0.32–0.35, ndarray
+0.15–0.17, and faer 0.22–0.24. The original unversioned aliases remain
+available for compatibility: they select nalgebra 0.34, ndarray 0.17, and faer
+0.24. When several releases of one backend are enabled, Basin uses the newest.
+The package MSRV is Rust 1.87; nalgebra 0.35 and `nalgebra_latest` require Rust
+1.89. The `problems` feature (a corpus of standard test functions) is on by
+default; disable it with `default-features = false` to shrink a wasm build.
 
 ## A Simple Example
 


### PR DESCRIPTION
## Summary

- Add exact Cargo features for nalgebra 0.32–0.35, ndarray 0.15–0.17, and faer 0.22–0.24, with moving `*_latest` aliases.
- Keep the original backend features pinned to their Basin 1.x versions, and select the newest release when Cargo enables several versions of the same backend.
- Move the development toolchain to Rust 1.89 while retaining Rust 1.87 as the package MSRV, checked in a dedicated CI job.
- Expand CI, tests, benchmarks, and documentation to cover the versioned feature model and matching sparse/LAPACK integrations.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] Latest and legacy backend test suites
- [x] Compile checks for every supported backend release
- [x] Rust 1.87 all-target MSRV check
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] Public rustdoc build with warnings denied
- [x] Default and no-default-feature WASM builds
- [x] nalgebra 0.32–0.35 LAPACK tests with OpenBLAS
- [x] Web formatting, type checks, and production build

`pnpm lint` still reports existing violations in unrelated web files and generated SVG assets.