### PR TITLE
chore(release): v1.9.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "04a3087b5ce644a1fa443db1c1364b03d13b207e",
+  "baseline-sha": "14065cac79707056b40ab6c3ad992c83c37d72e0",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.8.0",
-      "tag": "v1.8.0"
+      "version": "1.9.0",
+      "tag": "v1.9.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.8.0",
-      "tag": "v1.8.0"
+      "version": "1.9.0",
+      "tag": "v1.9.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.9.0](https://github.com/jolars/basin/compare/v1.8.0...v1.9.0) (2026-09-08)
+
+### Features
+- add globalized bounded Nelder-Mead ([`14065ca`](https://github.com/jolars/basin/commit/14065cac79707056b40ab6c3ad992c83c37d72e0))
+
+### Performance Improvements
+- reuse L-BFGS line search evaluations ([`da4f681`](https://github.com/jolars/basin/commit/da4f6814af8068f68f03bc521dca17488d0752bf))
+
 ## [1.8.0](https://github.com/jolars/basin/compare/v1.7.0...v1.8.0) (2026-09-07)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "competitor-bench"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "argmin",
  "argmin-math",

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "1.8.0"
+version = "1.9.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "1.8.0"
+version = "1.9.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM/GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "1.8.0"
+version = "1.9.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [1.9.0](https://github.com/jolars/basin/compare/v1.8.0...v1.9.0) (2026-09-08)

### Features
- add globalized bounded Nelder-Mead ([`14065ca`](https://github.com/jolars/basin/commit/14065cac79707056b40ab6c3ad992c83c37d72e0))

### Performance Improvements
- reuse L-BFGS line search evaluations ([`da4f681`](https://github.com/jolars/basin/commit/da4f6814af8068f68f03bc521dca17488d0752bf))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).