### PR TITLE
chore(release): v1.11.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "bdfa0541545f4a8db2209fae5553413442e2b939",
+  "baseline-sha": "f28e8dc1720b3692892feaed3eca06e43b5ee2c7",
   "release-targets": [
     {
       "path": ".",
-      "version": "1.10.0",
-      "tag": "v1.10.0"
+      "version": "1.11.0",
+      "tag": "v1.11.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "1.10.0",
-      "tag": "v1.10.0"
+      "version": "1.11.0",
+      "tag": "v1.11.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.11.0](https://github.com/jolars/basin/compare/v1.10.0...v1.11.0) (2026-09-11)
+
+### Features
+- add full-form nonlinear constraints ([`49df7ce`](https://github.com/jolars/basin/commit/49df7ce37408eb6c125303193696eee637a2bf30))
+- add optional LM trust-radius convergence ([`d2b6d84`](https://github.com/jolars/basin/commit/d2b6d8417ecf294319ff9fd496c2fca925103d0c))
+- stop LM on numerical no-progress ([`16c12c6`](https://github.com/jolars/basin/commit/16c12c6d698465bcde052ae1eb9e09845c1d4bf0))
+- make LM damping configurable ([`5ae5463`](https://github.com/jolars/basin/commit/5ae54633ba7e89a131c670ff3d6a2cb0c445f432))
+- move convergence settings onto solvers ([`fdf08ca`](https://github.com/jolars/basin/commit/fdf08cadd6b3daf2d86d585435215c4474353c7e))
+
+### Bug Fixes
+- harden LM stopping arithmetic ([`25d1b04`](https://github.com/jolars/basin/commit/25d1b04fc2386bd3a08b75fb8667c1d3d30c88fa))
+
+### Performance Improvements
+- **nelder-mead:** eliminate projected bound-vector clones (#95) ([`ad4ef87`](https://github.com/jolars/basin/commit/ad4ef87ee879df65b7a9ce9b9c3baf60e6470089))
+- **cobyla:** share signed and absolute dot reductions ([`b742f0c`](https://github.com/jolars/basin/commit/b742f0cba1be3b431fb99257f37d1362fb040b62))
+- **cobyla:** reuse trial buffers ([`d80a05a`](https://github.com/jolars/basin/commit/d80a05aadba9bb53c5e6ba184ae0fcbde1852d29))
+
 ## [1.10.0](https://github.com/jolars/basin/compare/v1.9.0...v1.10.0) (2026-09-10)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "basin"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "bincode",
  "criterion",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "basin-wasm"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "basin",
  "console_error_panic_hook",
@@ -314,13 +314,13 @@ dependencies = [
 
 [[package]]
 name = "cobyla"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7c3233e5d400a8fd61b50b79797d28a0657e4c0abeb41469b69d2d9d60ef3e"
+checksum = "d0461872f7e4e7216e1a770fbccc1b45a400247538d6b72be1a030b2427c64c4"
 
 [[package]]
 name = "competitor-bench"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -2278,9 +2278,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "spindle"

--- a/crates/basin-wasm/Cargo.toml
+++ b/crates/basin-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin-wasm"
-version = "1.10.0"
+version = "1.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/basin/Cargo.toml
+++ b/crates/basin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basin"
-version = "1.10.0"
+version = "1.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/competitor-bench/Cargo.toml
+++ b/crates/competitor-bench/Cargo.toml
@@ -21,7 +21,7 @@
 # support natively, so NM/GD run on identical param types.
 [package]
 name = "competitor-bench"
-version = "1.10.0"
+version = "1.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## [1.11.0](https://github.com/jolars/basin/compare/v1.10.0...v1.11.0) (2026-09-11)

### Features
- add full-form nonlinear constraints ([`49df7ce`](https://github.com/jolars/basin/commit/49df7ce37408eb6c125303193696eee637a2bf30))
- add optional LM trust-radius convergence ([`d2b6d84`](https://github.com/jolars/basin/commit/d2b6d8417ecf294319ff9fd496c2fca925103d0c))
- stop LM on numerical no-progress ([`16c12c6`](https://github.com/jolars/basin/commit/16c12c6d698465bcde052ae1eb9e09845c1d4bf0))
- make LM damping configurable ([`5ae5463`](https://github.com/jolars/basin/commit/5ae54633ba7e89a131c670ff3d6a2cb0c445f432))
- move convergence settings onto solvers ([`fdf08ca`](https://github.com/jolars/basin/commit/fdf08cadd6b3daf2d86d585435215c4474353c7e))

### Bug Fixes
- harden LM stopping arithmetic ([`25d1b04`](https://github.com/jolars/basin/commit/25d1b04fc2386bd3a08b75fb8667c1d3d30c88fa))

### Performance Improvements
- **nelder-mead:** eliminate projected bound-vector clones (#95) ([`ad4ef87`](https://github.com/jolars/basin/commit/ad4ef87ee879df65b7a9ce9b9c3baf60e6470089))
- **cobyla:** share signed and absolute dot reductions ([`b742f0c`](https://github.com/jolars/basin/commit/b742f0cba1be3b431fb99257f37d1362fb040b62))
- **cobyla:** reuse trial buffers ([`d80a05a`](https://github.com/jolars/basin/commit/d80a05aadba9bb53c5e6ba184ae0fcbde1852d29))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).